### PR TITLE
Added support for tls passphrase

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -442,7 +442,6 @@ static int MR_TlsPasswordCallback(char *buf, int size, int rwflag, void *u) {
     if (pass_len > (size_t) size) return -1;
     memcpy(buf, pass, pass_len);
 
-    RedisModule_Log(NULL, "warning", "inside password callback returned %s", buf);
     return (int) pass_len;
 }
 
@@ -462,9 +461,9 @@ SSL_CTX* MR_CreateSSLContext(const char *cacert_filename,
     SSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_PEER, NULL);
 
     /* always set the callback, otherwise if key is encrypted and password
-	 * was not given, we will be waiting on stdin. */
-	SSL_CTX_set_default_passwd_cb(ssl_ctx, MR_TlsPasswordCallback);
-	SSL_CTX_set_default_passwd_cb_userdata(ssl_ctx, (void *) private_key_pass);
+     * was not given, we will be waiting on stdin. */
+    SSL_CTX_set_default_passwd_cb(ssl_ctx, MR_TlsPasswordCallback);
+    SSL_CTX_set_default_passwd_cb_userdata(ssl_ctx, (void *) private_key_pass);
 
     if ((cert_filename != NULL && private_key_filename == NULL) ||
             (private_key_filename != NULL && cert_filename == NULL)) {

--- a/tests/mr_test_module/Makefile
+++ b/tests/mr_test_module/Makefile
@@ -41,10 +41,8 @@ test: build
 
 test_ssl: build
 	bash ./generate_tests_cert.sh
-	DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh --env-reuse -t ./pytests/ --env oss-cluster --shards-count 2 --tls --tls-cert-file ./tests/tls/redis.crt --tls-key-file ./tests/tls/redis.key --tls-ca-cert-file ./tests/tls/ca.crt
-	DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh --env-reuse -t ./pytests/ --env oss-cluster --shards-count 3 --tls --tls-cert-file ./tests/tls/redis.crt --tls-key-file ./tests/tls/redis.key --tls-ca-cert-file ./tests/tls/ca.crt
-	#DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh --env-reuse -t ./pytests/ --env oss-cluster --shards-count 2 --tls --tls-cert-file ./tests/tls/redis.crt --tls-key-file ./tests/tls/redis.key --tls-ca-cert-file ./tests/tls/ca.crt --tls-passphrase foobar
-	#DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh --env-reuse -t ./pytests/ --env oss-cluster --shards-count 3 --tls --tls-cert-file ./tests/tls/redis.crt --tls-key-file ./tests/tls/redis.key --tls-ca-cert-file ./tests/tls/ca.crt --tls-passphrase foobar
+	DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh --env-reuse -t ./pytests/ --env oss-cluster --shards-count 2 --tls --tls-cert-file ./tests/tls/redis.crt --tls-key-file ./tests/tls/redis.key --tls-ca-cert-file ./tests/tls/ca.crt --tls-passphrase foobar
+	DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh --env-reuse -t ./pytests/ --env oss-cluster --shards-count 3 --tls --tls-cert-file ./tests/tls/redis.crt --tls-key-file ./tests/tls/redis.key --tls-ca-cert-file ./tests/tls/ca.crt --tls-passphrase foobar
 
 test_valgrind: build
 	DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh --env-reuse -t ./pytests/ -V --vg-suppressions ./leakcheck.supp

--- a/tests/mr_test_module/Makefile
+++ b/tests/mr_test_module/Makefile
@@ -43,6 +43,8 @@ test_ssl: build
 	bash ./generate_tests_cert.sh
 	DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh --env-reuse -t ./pytests/ --env oss-cluster --shards-count 2 --tls --tls-cert-file ./tests/tls/redis.crt --tls-key-file ./tests/tls/redis.key --tls-ca-cert-file ./tests/tls/ca.crt
 	DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh --env-reuse -t ./pytests/ --env oss-cluster --shards-count 3 --tls --tls-cert-file ./tests/tls/redis.crt --tls-key-file ./tests/tls/redis.key --tls-ca-cert-file ./tests/tls/ca.crt
+	#DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh --env-reuse -t ./pytests/ --env oss-cluster --shards-count 2 --tls --tls-cert-file ./tests/tls/redis.crt --tls-key-file ./tests/tls/redis.key --tls-ca-cert-file ./tests/tls/ca.crt --tls-passphrase foobar
+	#DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh --env-reuse -t ./pytests/ --env oss-cluster --shards-count 3 --tls --tls-cert-file ./tests/tls/redis.crt --tls-key-file ./tests/tls/redis.key --tls-ca-cert-file ./tests/tls/ca.crt --tls-passphrase foobar
 
 test_valgrind: build
 	DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh --env-reuse -t ./pytests/ -V --vg-suppressions ./leakcheck.supp

--- a/tests/mr_test_module/generate_tests_cert.sh
+++ b/tests/mr_test_module/generate_tests_cert.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -x
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 ROOT=$(cd "$HERE" && pwd)
@@ -13,10 +14,12 @@ openssl req \
     -days 3650 \
     -subj '/O=Redis Test/CN=Certificate Authority' \
     -out ca.crt
+#openssl genrsa -out redis.key -aes256 -passout pass:foobar 2048
 openssl genrsa -out redis.key 2048
 openssl req \
     -new -sha256 \
     -key redis.key \
+    #-passin pass:foobar \
     -subj '/O=Redis Test/CN=Server' | \
     openssl x509 \
         -req -sha256 \

--- a/tests/mr_test_module/generate_tests_cert.sh
+++ b/tests/mr_test_module/generate_tests_cert.sh
@@ -18,8 +18,7 @@ openssl req \
 openssl genrsa -out redis.key 2048
 openssl req \
     -new -sha256 \
-    -key redis.key \
-    #-passin pass:foobar \
+    -key redis.key \ #-passin pass:foobar \
     -subj '/O=Redis Test/CN=Server' | \
     openssl x509 \
         -req -sha256 \

--- a/tests/mr_test_module/generate_tests_cert.sh
+++ b/tests/mr_test_module/generate_tests_cert.sh
@@ -18,7 +18,7 @@ openssl req \
 openssl genrsa -out redis.key 2048
 openssl req \
     -new -sha256 \
-    -key redis.key \ #-passin pass:foobar \
+    -key redis.key \
     -subj '/O=Redis Test/CN=Server' | \
     openssl x509 \
         -req -sha256 \

--- a/tests/mr_test_module/generate_tests_cert.sh
+++ b/tests/mr_test_module/generate_tests_cert.sh
@@ -14,11 +14,11 @@ openssl req \
     -days 3650 \
     -subj '/O=Redis Test/CN=Certificate Authority' \
     -out ca.crt
-#openssl genrsa -out redis.key -aes256 -passout pass:foobar 2048
-openssl genrsa -out redis.key 2048
+openssl genrsa -out redis.key -aes256 -passout pass:foobar 2048
 openssl req \
     -new -sha256 \
     -key redis.key \
+    -passin pass:foobar \
     -subj '/O=Redis Test/CN=Server' | \
     openssl x509 \
         -req -sha256 \


### PR DESCRIPTION
The PR adds support for tls passphrase by reading the 'tls-key-file-pass' configuration from Redis and use it (if exists) when reading the key file.

- [x] Require this fix on RLTest to be able to test it on CI: https://github.com/RedisLabsModules/RLTest/pull/154

Tested locally by tweaking RLTest, redispy, and redispy cluster.