### PR TITLE
Removing LGTM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 [![Release](https://img.shields.io/github/release/RedisGears/LibMR.svg?sort=semver)](https://github.com/RedisGears/LibMR/releases)
 [![CircleCI](https://circleci.com/gh/RedisGears/LibMR/tree/master.svg?style=svg)](https://circleci.com/gh/RedisGears/LibMR/tree/master)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/RedisGears/LibMR.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/RedisGears/LibMR/alerts/)
 [![codecov](https://codecov.io/gh/RedisGears/LibMR/branch/master/graph/badge.svg)](https://codecov.io/gh/RedisGears/LibMRs)
 
 # LibMR
 [![Forum](https://img.shields.io/badge/Forum-RedisGears-blue)](https://forum.redislabs.com/c/modules/redisgears)
 [![Discord](https://img.shields.io/discord/697882427875393627?style=flat-square)](https://discord.gg/6yaVTtp)
 
-LibMR is a Map Reduce library that runs on top of Redis Cluster and agnostic to the deployment (oss/oss-cluster/enterpris-cluster). 
+LibMR is a Map Reduce library that runs on top of Redis Cluster and agnostic to the deployment (oss/oss-cluster/enterpris-cluster).
 
 # Build
 


### PR DESCRIPTION
The LGTM service is being shut off in two weeks. This pull request aims to remove all references to LGTM. Perhaps LGTM usage should be replaced with codeql, or a repository preferred tool, but IMHO that's the point of a different pull request.