### PR TITLE
add password to mr_init

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -105,6 +105,7 @@ struct ClusterCtx {
     char myId[REDISMODULE_NODE_ID_LEN + 1];
     int isOss;
     functionId networkTestMsgReciever;
+    char *password;
 }clusterCtx;
 
 typedef struct ClusterSetCtx {
@@ -770,7 +771,7 @@ static void MR_RefreshClusterData(){
 
         Node* n = MR_GetNode(nodeId);
         if(!n){
-            n = MR_CreateNode(nodeId, nodeIp, (unsigned short)port, NULL, NULL, minslot, maxslot);
+            n = MR_CreateNode(nodeId, nodeIp, (unsigned short)port, clusterCtx.password, NULL, minslot, maxslot);
         }
 
         if (n->isMe) {
@@ -1242,7 +1243,7 @@ static void MR_NetworkTest(RedisModuleCtx *ctx, const char *sender_id, uint8_t t
     RedisModule_Log(ctx, "notice", "got a nextwork test msg");
 }
 
-int MR_ClusterInit(RedisModuleCtx* rctx) {
+int MR_ClusterInit(RedisModuleCtx* rctx, char *password) {
     clusterCtx.CurrCluster = NULL;
     clusterCtx.callbacks = array_new(MR_ClusterMessageReceiver, 10);
     clusterCtx.nodesMsgIds = mr_dictCreate(&mr_dictTypeHeapStrings, NULL);
@@ -1250,6 +1251,7 @@ int MR_ClusterInit(RedisModuleCtx* rctx) {
     clusterCtx.maxSlot = 0;
     clusterCtx.clusterSize = 1;
     clusterCtx.isOss = true;
+    clusterCtx.password = MR_STRDUP(password);
     memset(clusterCtx.myId, '0', REDISMODULE_NODE_ID_LEN);
 
     RedisModuleServerInfoData *info = RedisModule_GetServerInfo(rctx, "Server");

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -37,7 +37,7 @@ int MR_IsClusterInitialize();
 
 size_t MR_ClusterGetSize();
 
-int MR_ClusterInit(RedisModuleCtx* rctx);
+int MR_ClusterInit(RedisModuleCtx* rctx, char *password);
 
 size_t MR_ClusterGetSlotdByKey(const char* key, size_t len);
 

--- a/src/mr.c
+++ b/src/mr.c
@@ -1344,10 +1344,10 @@ void MR_FreeExecution(Execution* e) {
     MR_FREE(e);
 }
 
-int MR_Init(RedisModuleCtx* ctx, size_t numThreads) {
+int MR_Init(RedisModuleCtx* ctx, size_t numThreads, char *password) {
     mr_staticCtx = RedisModule_GetDetachedThreadSafeContext(ctx);
 
-    if (MR_ClusterInit(ctx) != REDISMODULE_OK) {
+    if (MR_ClusterInit(ctx, password) != REDISMODULE_OK) {
         return REDISMODULE_ERR;
     }
 

--- a/src/mr.h
+++ b/src/mr.h
@@ -121,7 +121,7 @@ LIBMR_API void MR_Run(Execution* e);
 LIBMR_API void MR_FreeExecution(Execution* e);
 
 /* Initialize mr library */
-LIBMR_API int MR_Init(struct RedisModuleCtx* ctx, size_t numThreads);
+LIBMR_API int MR_Init(struct RedisModuleCtx* ctx, size_t numThreads, char *password);
 
 /* Register a new object type */
 LIBMR_API int MR_RegisterObject(MRObjectType* t);

--- a/tests/mr_test_module/pytests/run_tests.sh
+++ b/tests/mr_test_module/pytests/run_tests.sh
@@ -12,4 +12,4 @@ else
 fi
 
 
-python3 -m RLTest --module $MODULE_PATH --clear-logs "$@" --module-args --oss_password "my_password"
+python3 -m RLTest --module $MODULE_PATH --clear-logs "$@" --module-args "my_password" --oss_password "my_password"

--- a/tests/mr_test_module/pytests/run_tests.sh
+++ b/tests/mr_test_module/pytests/run_tests.sh
@@ -12,4 +12,4 @@ else
 fi
 
 
-python3 -m RLTest --module $MODULE_PATH --clear-logs "$@" --module-args "my_password" --oss_password "my_password"
+python3 -m RLTest --module $MODULE_PATH --clear-logs "$@" --module-args "password" --oss_password "password"

--- a/tests/mr_test_module/pytests/run_tests.sh
+++ b/tests/mr_test_module/pytests/run_tests.sh
@@ -12,4 +12,4 @@ else
 fi
 
 
-python3 -m RLTest --module $MODULE_PATH --clear-logs "$@"
+python3 -m RLTest --module $MODULE_PATH --clear-logs "$@" --oss_password "my_password"

--- a/tests/mr_test_module/pytests/run_tests.sh
+++ b/tests/mr_test_module/pytests/run_tests.sh
@@ -12,4 +12,4 @@ else
 fi
 
 
-python3 -m RLTest --module $MODULE_PATH --clear-logs "$@" --oss_password "my_password"
+python3 -m RLTest --module $MODULE_PATH --clear-logs "$@" --module-args --oss_password "my_password"

--- a/tests/mr_test_module/src/include/mr.h
+++ b/tests/mr_test_module/src/include/mr.h
@@ -121,7 +121,7 @@ LIBMR_API void MR_Run(Execution* e);
 LIBMR_API void MR_FreeExecution(Execution* e);
 
 /* Initialize mr library */
-LIBMR_API int MR_Init(RedisModuleCtx* ctx, size_t numThreads);
+LIBMR_API int MR_Init(RedisModuleCtx* ctx, size_t numThreads, char *password);
 
 /* Register a new object type */
 LIBMR_API int MR_RegisterObject(MRObjectType* t);

--- a/tests/mr_test_module/src/lib.rs
+++ b/tests/mr_test_module/src/lib.rs
@@ -887,8 +887,7 @@ static mut INT_RECORD_TYPE: Option<RecordType<IntRecord>> = None;
 fn init_func(ctx: &Context, _args: &Vec<RedisString>) -> Status {
     unsafe{
         DETACHED_CTX = RedisModule_GetDetachedThreadSafeContext.unwrap()(ctx.ctx);
-
-        MR_Init(ctx.ctx as *mut libmrraw::bindings::RedisModuleCtx, 3);
+        MR_Init(ctx.ctx as *mut libmrraw::bindings::RedisModuleCtx, 3, RedisModule_StringPtrLen(_args[0], ptr::null_mut()));
     }
 
     unsafe{

--- a/tests/mr_test_module/src/lib.rs
+++ b/tests/mr_test_module/src/lib.rs
@@ -889,8 +889,8 @@ static mut INT_RECORD_TYPE: Option<RecordType<IntRecord>> = None;
 fn init_func(ctx: &Context, args: &Vec<RedisString>) -> Status {
     unsafe{
         DETACHED_CTX = RedisModule_GetDetachedThreadSafeContext.unwrap()(ctx.ctx);
-        let mut passwd = args.get(0).map(|v| RedisModule_StringPtrLen.unwrap()(v.inner, ptr::null_mut())).unwrap_or(ptr::null_mut());
-        MR_Init(ctx.ctx as *mut libmrraw::bindings::RedisModuleCtx, 3, passwd);
+        let passwd = args.get(0).map(|v| RedisModule_StringPtrLen.unwrap()(v.inner, ptr::null_mut())).unwrap_or(ptr::null_mut());
+        MR_Init(ctx.ctx as *mut libmrraw::bindings::RedisModuleCtx, 3, passwd as *mut c_char);
     }
 
     unsafe{

--- a/tests/mr_test_module/src/lib.rs
+++ b/tests/mr_test_module/src/lib.rs
@@ -887,7 +887,7 @@ static mut INT_RECORD_TYPE: Option<RecordType<IntRecord>> = None;
 fn init_func(ctx: &Context, args: &Vec<RedisString>) -> Status {
     unsafe{
         DETACHED_CTX = RedisModule_GetDetachedThreadSafeContext.unwrap()(ctx.ctx);
-        let passwd = if args.len() > 0 {RedisModule_StringPtrLen(args[0], ptr::null_mut())} else {ptr::null_mut()};
+        let passwd = args.get(0).map(|v| RedisModule_StringPtrLen(v, ptr::null_mut())).unwrap_or(ptr::null_mut());
         MR_Init(ctx.ctx as *mut libmrraw::bindings::RedisModuleCtx, 3, passwd);
     }
 

--- a/tests/mr_test_module/src/lib.rs
+++ b/tests/mr_test_module/src/lib.rs
@@ -889,7 +889,7 @@ static mut INT_RECORD_TYPE: Option<RecordType<IntRecord>> = None;
 fn init_func(ctx: &Context, args: &Vec<RedisString>) -> Status {
     unsafe{
         DETACHED_CTX = RedisModule_GetDetachedThreadSafeContext.unwrap()(ctx.ctx);
-        let passwd = args.get(0).map(|v| RedisModule_StringPtrLen.unwrap()(v, ptr::null_mut())).unwrap_or(ptr::null_mut());
+        let mut passwd = args.get(0).map(|v| RedisModule_StringPtrLen.unwrap()(v.inner, ptr::null_mut())).unwrap_or(ptr::null_mut());
         MR_Init(ctx.ctx as *mut libmrraw::bindings::RedisModuleCtx, 3, passwd);
     }
 

--- a/tests/mr_test_module/src/lib.rs
+++ b/tests/mr_test_module/src/lib.rs
@@ -884,10 +884,11 @@ impl Drop for KeysReader {
 static mut HASH_RECORD_TYPE: Option<RecordType<StringRecord>> = None;
 static mut INT_RECORD_TYPE: Option<RecordType<IntRecord>> = None;
 
-fn init_func(ctx: &Context, _args: &Vec<RedisString>) -> Status {
+fn init_func(ctx: &Context, args: &Vec<RedisString>) -> Status {
     unsafe{
         DETACHED_CTX = RedisModule_GetDetachedThreadSafeContext.unwrap()(ctx.ctx);
-        MR_Init(ctx.ctx as *mut libmrraw::bindings::RedisModuleCtx, 3, RedisModule_StringPtrLen(_args[0], ptr::null_mut()));
+        let passwd = if args.len() > 0 {RedisModule_StringPtrLen(args[0], ptr::null_mut())} else {ptr::null_mut()};
+        MR_Init(ctx.ctx as *mut libmrraw::bindings::RedisModuleCtx, 3, passwd);
     }
 
     unsafe{

--- a/tests/mr_test_module/src/lib.rs
+++ b/tests/mr_test_module/src/lib.rs
@@ -18,6 +18,7 @@ use redis_module::redisraw::bindings::{
     RedisModule_ThreadSafeContextLock,
     RedisModule_ThreadSafeContextUnlock,
     RedisModule_ScanCursorDestroy,
+    RedisModule_StringPtrLen
 };
 
 use redis_module::{

--- a/tests/mr_test_module/src/lib.rs
+++ b/tests/mr_test_module/src/lib.rs
@@ -18,7 +18,7 @@ use redis_module::redisraw::bindings::{
     RedisModule_ThreadSafeContextLock,
     RedisModule_ThreadSafeContextUnlock,
     RedisModule_ScanCursorDestroy,
-    RedisModule_StringPtrLen
+    RedisModule_StringPtrLen,
 };
 
 use redis_module::{
@@ -33,6 +33,7 @@ use redis_module::{
     ThreadSafeContext,
 };
 
+use std::ptr;
 use std::str;
 
 mod libmrraw;
@@ -888,7 +889,7 @@ static mut INT_RECORD_TYPE: Option<RecordType<IntRecord>> = None;
 fn init_func(ctx: &Context, args: &Vec<RedisString>) -> Status {
     unsafe{
         DETACHED_CTX = RedisModule_GetDetachedThreadSafeContext.unwrap()(ctx.ctx);
-        let passwd = args.get(0).map(|v| RedisModule_StringPtrLen(v, ptr::null_mut())).unwrap_or(ptr::null_mut());
+        let passwd = args.get(0).map(|v| RedisModule_StringPtrLen.unwrap()(v, ptr::null_mut())).unwrap_or(ptr::null_mut());
         MR_Init(ctx.ctx as *mut libmrraw::bindings::RedisModuleCtx, 3, passwd);
     }
 


### PR DESCRIPTION
The password are given to lib_mr on `mr_init` and will be used by libmr to connect to the other shards when used with OSS cluster.
Will fix: https://github.com/RedisTimeSeries/RedisTimeSeries/issues/1215