### PR TITLE
Fix tls on Redis 7.2 oss cluster

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         test_args: ["", "-V --vg-suppressions ../leakcheck.supp"]
-        redis_version: ["7.0.10", "7.2-rc1"]
+        redis_version: ["7.0.10", "7.2.1"]
 
     steps:
     - uses: actions/checkout@v3

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -771,7 +771,7 @@ static void MR_RefreshClusterData(){
         // We need to get the port using the `RedisModule_GetClusterNodeInfo` API because on 7.2
         // invoking `cluster slot` from RM_Call will always return the none tls port.
         // For for information refer to: https://github.com/redis/redis/pull/12233
-        long long port = 0;
+        int port = 0;
         RedisModule_ThreadSafeContextLock(mr_staticCtx);
         RedisModule_GetClusterNodeInfo(mr_staticCtx, nodeId, NULL, NULL, &port, NULL);
         RedisModule_ThreadSafeContextUnlock(mr_staticCtx);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -754,13 +754,11 @@ static void MR_RefreshClusterData(){
         RedisModule_Assert(RedisModule_CallReplyType(nodeDetailsRelpy) == REDISMODULE_REPLY_ARRAY);
         RedisModule_Assert(RedisModule_CallReplyLength(nodeDetailsRelpy) >= 3);
         RedisModuleCallReply *nodeipReply = RedisModule_CallReplyArrayElement(nodeDetailsRelpy, 0);
-        RedisModuleCallReply *nodeportReply = RedisModule_CallReplyArrayElement(nodeDetailsRelpy, 1);
         RedisModuleCallReply *nodeidReply = RedisModule_CallReplyArrayElement(nodeDetailsRelpy, 2);
         size_t idLen;
         size_t ipLen;
         const char* id = RedisModule_CallReplyStringPtr(nodeidReply,&idLen);
         const char* ip = RedisModule_CallReplyStringPtr(nodeipReply,&ipLen);
-        long long port = RedisModule_CallReplyInteger(nodeportReply);
 
         char nodeId[REDISMODULE_NODE_ID_LEN + 1];
         memcpy(nodeId, id, REDISMODULE_NODE_ID_LEN);
@@ -769,6 +767,15 @@ static void MR_RefreshClusterData(){
         char nodeIp[ipLen + 1];
         memcpy(nodeIp, ip, ipLen);
         nodeIp[ipLen] = '\0';
+
+        // We need to get the port using the `RedisModule_GetClusterNodeInfo` API because on 7.2
+        // invoking `cluster slot` from RM_Call will always return the none tls port.
+        // For for information refer to: https://github.com/redis/redis/pull/12233
+        long long port = 0;
+        RedisModule_ThreadSafeContextLock(mr_staticCtx);
+        RedisModule_GetClusterNodeInfo(mr_staticCtx, nodeId, NULL, NULL, &port, NULL);
+        RedisModule_ThreadSafeContextUnlock(mr_staticCtx);
+
 
         Node* n = MR_GetNode(nodeId);
         if(!n){


### PR DESCRIPTION
On Redis 7.2 (specifically on 7.2-rc3) there was a [change](https://github.com/redis/redis/pull/12233) made that allow running on cluster with both, tls and none tls port.
As part of this change, `cluster slot` command will return the port base of the connection type (tls or not tls). A side effect of this change is that when `cluster slot` called using `RM_Call` it is always gets the none tls port (which break our support for tls).

To fix this, use `RedisModule_GetClusterNodeInfo` Redis module API to get the correct port.

Notice that this is a minimal fix, we should extend the Redis module API to provide us with all the information we need (including slot range) so we will not have to use `cluster slot` command at all.