### PR TITLE
Added _proxy-filtered flag to internal commands

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,7 +31,7 @@ jobs:
       run: git clone https://github.com/redis/redis; cd redis; git checkout ${{ matrix.redis_version }}; BUILD_TLS=yes make valgrind install
     - name: install valgrind
       run: |
-        sudo apt-get update --fix-mssing
+        sudo apt-get update --fix-missing
         sudo apt-get install valgrind
     - name: Build
       run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,7 +30,9 @@ jobs:
     - name: install redis
       run: git clone https://github.com/redis/redis; cd redis; git checkout ${{ matrix.redis_version }}; BUILD_TLS=yes make valgrind install
     - name: install valgrind
-      run: sudo apt-get install valgrind
+      run: |
+        sudo apt-get update --fix-mssing
+        sudo apt-get install valgrind
     - name: Build
       run: |
         cd tests/mr_test_module/

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1301,42 +1301,47 @@ int MR_ClusterInit(RedisModuleCtx* rctx, char *password) {
 
     RedisModule_Log(rctx, "notice", "Detected redis %s", clusterCtx.isOss? "oss" : "enterprise");
 
-    if (RedisModule_CreateCommand(rctx, CLUSTER_REFRESH_COMMAND, MR_ClusterRefresh, "readonly deny-script", 0, 0, 0) != REDISMODULE_OK) {
+    const char *command_flags = "readonly deny-script";
+    if (MR_IsEnterpriseBuild()) {
+        command_flags = "readonly deny-script _proxy-filtered";
+    }
+
+    if (RedisModule_CreateCommand(rctx, CLUSTER_REFRESH_COMMAND, MR_ClusterRefresh, command_flags, 0, 0, 0) != REDISMODULE_OK) {
         RedisModule_Log(rctx, "warning", "could not register command " CLUSTER_REFRESH_COMMAND);
         return REDISMODULE_ERR;
     }
 
-    if (RedisModule_CreateCommand(rctx, CLUSTER_SET_COMMAND, MR_ClusterSet, "readonly deny-script", 0, 0, -1) != REDISMODULE_OK) {
+    if (RedisModule_CreateCommand(rctx, CLUSTER_SET_COMMAND, MR_ClusterSet, command_flags, 0, 0, -1) != REDISMODULE_OK) {
         RedisModule_Log(rctx, "warning", "could not register command " CLUSTER_SET_COMMAND);
         return REDISMODULE_ERR;
     }
 
-    if (RedisModule_CreateCommand(rctx, CLUSTER_SET_FROM_SHARD_COMMAND, MR_ClusterSetFromShard, "readonly deny-script", 0, 0, -1) != REDISMODULE_OK) {
+    if (RedisModule_CreateCommand(rctx, CLUSTER_SET_FROM_SHARD_COMMAND, MR_ClusterSetFromShard, command_flags, 0, 0, -1) != REDISMODULE_OK) {
         RedisModule_Log(rctx, "warning", "could not register command "CLUSTER_SET_FROM_SHARD_COMMAND);
         return REDISMODULE_ERR;
     }
 
-    if (RedisModule_CreateCommand(rctx, CLUSTER_HELLO_COMMAND, MR_ClusterHello, "readonly deny-script", 0, 0, 0) != REDISMODULE_OK) {
+    if (RedisModule_CreateCommand(rctx, CLUSTER_HELLO_COMMAND, MR_ClusterHello, command_flags, 0, 0, 0) != REDISMODULE_OK) {
         RedisModule_Log(rctx, "warning", "could not register command "CLUSTER_HELLO_COMMAND);
         return REDISMODULE_ERR;
     }
 
-    if (RedisModule_CreateCommand(rctx, CLUSTER_INNER_COMMUNICATION_COMMAND, MR_ClusterInnerCommunicationMsg, "readonly deny-script", 0, 0, 0) != REDISMODULE_OK) {
+    if (RedisModule_CreateCommand(rctx, CLUSTER_INNER_COMMUNICATION_COMMAND, MR_ClusterInnerCommunicationMsg, command_flags, 0, 0, 0) != REDISMODULE_OK) {
         RedisModule_Log(rctx, "warning", "could not register command "CLUSTER_INNER_COMMUNICATION_COMMAND);
         return REDISMODULE_ERR;
     }
 
-    if (RedisModule_CreateCommand(rctx, NETWORK_TEST_COMMAND, MR_NetworkTestCommand, "readonly deny-script", 0, 0, 0) != REDISMODULE_OK) {
+    if (RedisModule_CreateCommand(rctx, NETWORK_TEST_COMMAND, MR_NetworkTestCommand, command_flags, 0, 0, 0) != REDISMODULE_OK) {
         RedisModule_Log(rctx, "warning", "could not register command "NETWORK_TEST_COMMAND);
         return REDISMODULE_ERR;
     }
 
-    if (RedisModule_CreateCommand(rctx, CLUSTER_INFO_COMMAND, MR_ClusterInfoCommand, "readonly deny-script", 0, 0, 0) != REDISMODULE_OK) {
+    if (RedisModule_CreateCommand(rctx, CLUSTER_INFO_COMMAND, MR_ClusterInfoCommand, command_flags, 0, 0, 0) != REDISMODULE_OK) {
         RedisModule_Log(rctx, "warning", "could not register command "CLUSTER_INFO_COMMAND);
         return REDISMODULE_ERR;
     }
 
-    if (RedisModule_CreateCommand(rctx, FORCE_SHARDS_CONNECTION, MR_ForceShardsConnectionCommand, "readonly deny-script", 0, 0, 0) != REDISMODULE_OK) {
+    if (RedisModule_CreateCommand(rctx, FORCE_SHARDS_CONNECTION, MR_ForceShardsConnectionCommand, command_flags, 0, 0, 0) != REDISMODULE_OK) {
         RedisModule_Log(rctx, "warning", "could not register command "FORCE_SHARDS_CONNECTION);
         return REDISMODULE_ERR;
     }

--- a/src/common.h
+++ b/src/common.h
@@ -4,3 +4,22 @@
 #ifndef MODULE_NAME
 #error "MODULE_NAME is not defined"
 #endif
+
+typedef struct MR_RedisVersion
+{
+    int redisMajorVersion;
+    int redisMinorVersion;
+    int redisPatchVersion;
+} MR_RedisVersion;
+
+extern MR_RedisVersion MR_currVersion;
+
+extern int MR_RlecMajorVersion;
+extern int MR_RlecMinorVersion;
+extern int MR_RlecPatchVersion;
+extern int MR_RlecBuild;
+extern int MR_IsEnterprise;
+
+static inline int MR_IsEnterpriseBuild() {
+    return MR_IsEnterprise;
+}


### PR DESCRIPTION
Added `_proxy-filtered` flag to all internal commands. The flag should only be added on enterprise build and will make sure the commands are not appeared on slow log, `command` command, and other location where we do not want to expose them.