### PR TITLE
MOD-5647 fix crash on ssl initialization failure

### DIFF
--- a/src/utils/thpool.c
+++ b/src/utils/thpool.c
@@ -124,7 +124,10 @@ static void mr_thpool_start_threads(mr_thpool_* thpool_p) {
     }
 
     /* Wait for threads to initialize */
-    while (thpool_p->num_threads_alive != thpool_p->total_num_of_threads) {}
+    while (thpool_p->num_threads_alive != thpool_p->total_num_of_threads) {
+        // avoid busy loop, wait for a very small amount of time.
+        usleep(1);
+    }
 
     thpool_p->is_threads_started = 1;
     pthread_mutex_unlock(&thpool_p->is_threads_started_lock);

--- a/tests/mr_test_module/pytests/common.py
+++ b/tests/mr_test_module/pytests/common.py
@@ -77,6 +77,24 @@ def runSkipTests():
 def waitBeforeTestStart():
     return True if os.environ.get('HOLD', False) else False
 
+def shardsConnections(env):
+    for s in range(1, env.shardsCount + 1):
+        yield env.getConnection(shardId=s)
+
+def verifyClusterInitialized(env):
+    for conn in shardsConnections(env):
+        allConnected = False
+        while not allConnected:
+            res = conn.execute_command('MRTESTS.INFOCLUSTER')
+            nodes = res[4]
+            allConnected = True
+            for n in nodes:
+                status = n[17]
+                if status != 'connected':
+                    allConnected = False
+            if not allConnected:
+                time.sleep(0.1)
+
 def MRTestDecorator(skipTest=False, skipOnSingleShard=False, skipOnCluster=False, skipOnValgrind=False, envArgs={}):
     def test_func_generator(test_function):
         def test_func():
@@ -99,11 +117,15 @@ def MRTestDecorator(skipTest=False, skipOnSingleShard=False, skipOnCluster=False
                 'env': env,
                 'conn': conn
             }
-            env.broadcast('MRTESTS.REFRESHCLUSTER')
-            # make sure cluster will not turn to failed state and we will not be
-            # able to execute commands on shards, on slow envs, run with valgrind,
-            # or mac, it is needed.
-            env.broadcast('CONFIG', 'set', 'cluster-node-timeout', '60000')
+            if env.isCluster():
+                # make sure cluster will not turn to failed state and we will not be
+                # able to execute commands on shards, on slow envs, run with valgrind,
+                # or mac, it is needed.
+                env.broadcast('CONFIG', 'set', 'cluster-node-timeout', '120000')
+                env.broadcast('MRTESTS.REFRESHCLUSTER')
+                env.broadcast('MRTESTS.FORCESHARDSCONNECTION')
+                with TimeLimit(2):
+                    verifyClusterInitialized(env)
             if waitBeforeTestStart():
                 input('\tpress any button to continue test %s' % test_name)
             test_function(**args)

--- a/tests/mr_test_module/pytests/common.py
+++ b/tests/mr_test_module/pytests/common.py
@@ -117,12 +117,12 @@ def MRTestDecorator(skipTest=False, skipOnSingleShard=False, skipOnCluster=False
                 'env': env,
                 'conn': conn
             }
+            env.broadcast('MRTESTS.REFRESHCLUSTER')
             if env.isCluster():
                 # make sure cluster will not turn to failed state and we will not be
                 # able to execute commands on shards, on slow envs, run with valgrind,
                 # or mac, it is needed.
                 env.broadcast('CONFIG', 'set', 'cluster-node-timeout', '120000')
-                env.broadcast('MRTESTS.REFRESHCLUSTER')
                 env.broadcast('MRTESTS.FORCESHARDSCONNECTION')
                 with TimeLimit(2):
                     verifyClusterInitialized(env)

--- a/tests/mr_test_module/pytests/common.py
+++ b/tests/mr_test_module/pytests/common.py
@@ -100,6 +100,10 @@ def MRTestDecorator(skipTest=False, skipOnSingleShard=False, skipOnCluster=False
                 'conn': conn
             }
             env.broadcast('MRTESTS.REFRESHCLUSTER')
+            # make sure cluster will not turn to failed state and we will not be
+            # able to execute commands on shards, on slow envs, run with valgrind,
+            # or mac, it is needed.
+            env.broadcast('CONFIG', 'set', 'cluster-node-timeout', '60000')
             if waitBeforeTestStart():
                 input('\tpress any button to continue test %s' % test_name)
             test_function(**args)

--- a/tests/mr_test_module/pytests/run_tests.sh
+++ b/tests/mr_test_module/pytests/run_tests.sh
@@ -19,4 +19,4 @@ else
 fi
 
 
-python3 -m RLTest --module $MODULE_PATH --clear-logs "$@" --module-args "password" --oss_password "password"
+python3 -m RLTest --verbose-information-on-failure --module $MODULE_PATH --clear-logs "$@" --module-args "password" --oss_password "password"

--- a/tests/mr_test_module/src/lib.rs
+++ b/tests/mr_test_module/src/lib.rs
@@ -360,6 +360,7 @@ fn lmr_read_all_keys(ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
         .collect()
         .create_execution()
         .map_err(|e| RedisError::String(e))?;
+    execution.set_max_idle(90000);
     let blocked_client = ctx.block_client();
     execution.set_done_hanlder(|mut res, mut errs| {
         let thread_ctx = ThreadSafeContext::with_blocked_client(blocked_client);


### PR DESCRIPTION
The PR fixes a crash on hiredis where the SSL initialization fails. It seems that hiredis do not unset the callbacks that was set by the `redisInitiateSSL` in case of a failure, and so later those callbacks might be called when the SSL context is not initialized and cause a crash.

And issue was open upstream to fix it on hiredis itself: https://github.com/redis/hiredis/issues/1233

In addition the PR add fixes for flaky tests.