### PR TITLE
Fix compile issues

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -513,7 +513,7 @@ error:
     return NULL;
 }
 
-static void MR_OnConnectCallback(struct redisAsyncContext* c, int status){
+static void MR_OnConnectCallback(const struct redisAsyncContext* c, int status){
     if(!c->data){
         return;
     }
@@ -553,7 +553,7 @@ static void MR_OnConnectCallback(struct redisAsyncContext* c, int status){
                 // This is a temporary fix to the bug describe on https://github.com/redis/hiredis/issues/1233.
                 // In case of SSL initialization failure. We need to reset the callbacks value, as the `redisInitiateSSL`
                 // function will not do it for us.
-                c->c.funcs = old_callbacks;
+                ((struct redisAsyncContext*)c)->c.funcs = old_callbacks;
                 RedisModule_Log(mr_staticCtx, "warning", "SSL auth to %s:%d failed, will initiate retry. %s.", c->c.tcp.host, c->c.tcp.port, err);
                 // disconnect async, its not possible to free redisAsyncContext here
                 MR_EventLoopAddTask(MR_ClusterAsyncDisconnect, n);

--- a/src/common.h
+++ b/src/common.h
@@ -1,3 +1,12 @@
+/*
+ * Copyright Redis Ltd. 2021 - present
+ * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ * the Server Side Public License v1 (SSPLv1).
+ */
+
+#ifndef SRC_COMMON_H_
+#define SRC_COMMON_H_
+
 #define xstr(s) str(s)
 #define str(s) #s
 
@@ -23,3 +32,5 @@ extern int MR_IsEnterprise;
 static inline int MR_IsEnterpriseBuild() {
     return MR_IsEnterprise;
 }
+
+#endif /* SRC_COMMON_H_ */


### PR DESCRIPTION
- Missing include guard for common.h fails the build on my local
- [redisAsyncSetConnectCallback()](https://github.com/RedisGears/LibMR/blame/d87f186bf62bbb2fb946853bbd7052be4c359aa1/src/cluster.c#L595) expects const pointer argument in the callback. Currently, compiler prints a warning. Added a cast to workaround the issue. 