### PR TITLE
MOD-15749 Add support for short form of CLUSTERSET

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -986,15 +986,15 @@ static void SetMyId(Cluster* cluster, RedisModuleString** argv, int argc){
 }
 
 static void InitClusterData(Cluster* cluster, RedisModuleString** argv, int argc){
-    clusterCtx.CurrCluster->clusterSetCommand = MR_ALLOC(sizeof(char*) * argc);
-    clusterCtx.CurrCluster->clusterSetCommandSize = argc;
-    clusterCtx.CurrCluster->clusterSetCommand[0] = MR_STRDUP(CLUSTER_SET_FROM_SHARD_COMMAND);
+    cluster->clusterSetCommand = MR_ALLOC(sizeof(char*) * argc);
+    cluster->clusterSetCommandSize = argc;
+    cluster->clusterSetCommand[0] = MR_STRDUP(CLUSTER_SET_FROM_SHARD_COMMAND);
 
-    GenerateRunId(clusterCtx.CurrCluster);
-    CopyClusterSetArgs(clusterCtx.CurrCluster, argv, argc);
-    SetMyId(clusterCtx.CurrCluster, argv, argc);
+    GenerateRunId(cluster);
+    CopyClusterSetArgs(cluster, argv, argc);
+    SetMyId(cluster, argv, argc);
 
-    clusterCtx.CurrCluster->nodes = mr_dictCreate(&mr_dictTypeHeapStrings, NULL);
+    cluster->nodes = mr_dictCreate(&mr_dictTypeHeapStrings, NULL);
 }
 
 #define INTERNAL_PASSWORD_MAX_SIZE 100

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1133,8 +1133,6 @@ static void SetClusterDataShortForm(RedisModuleString** argv, int argc){
 
         if (!(flags & REDISMODULE_NODE_MASTER)) continue;  // Skip replica nodes
 
-        RedisModule_Assert(MR_GetNode(nodeId) == NULL);
-
         RedisModuleSlotRangeArray *slots = RedisModule_GetClusterNodeSlotRanges(mr_staticCtx, nodeId);
         RedisModule_Assert(slots != NULL);
         long long minSlot = 0, maxSlot = -1;  // min > max indicates a no-hslots range (i.e., used for slotless shards)

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1152,10 +1152,11 @@ static void SetClusterDataShortForm(RedisModuleString** argv, int argc){
             clusterCtx.maxSlot = maxSlot;
         }
 
-        for (size_t j = 1; j < slots->num_ranges; j++) {
+        for (size_t j = 0; j < slots->num_ranges; j++) {
             minSlot = slots->ranges[j].start;
             maxSlot = slots->ranges[j].end;
-            mr_listAddNodeTail(aMasterNode->slotRanges, NewSlotRange(minSlot, maxSlot));
+            if (j > 0)  // The 0 case is handled by the MR_CreateNode() above
+                mr_listAddNodeTail(aMasterNode->slotRanges, NewSlotRange(minSlot, maxSlot));
             for (uint16_t k = minSlot ; k <= maxSlot ; k++)
                 clusterCtx.CurrCluster->slots[k] = aMasterNode;
         }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -699,7 +699,7 @@ static void MR_OnConnectCallback(const struct redisAsyncContext* c, int status){
 
     if(n->sendClusterTopologyOnNextConnect && clusterCtx.CurrCluster->clusterSetCommand){
         bool isLongForm = IsLongFormClusterSet(clusterCtx.CurrCluster->clusterSetCommandSize);
-        RedisModule_Log(mr_staticCtx, "notice", "Sending cluster (%s form) topology to %s (%s:%d) on after reconnect",
+        RedisModule_Log(mr_staticCtx, "notice", "Sending cluster (%s form) topology to %s (%s:%d) after reconnect",
                 isLongForm ? "long" : "short", n->id, n->ip, n->port);
         if (isLongForm)
             clusterCtx.CurrCluster->clusterSetCommand[CLUSTERSET_MYID_LONG_FORM_INDEX] = MR_STRDUP(n->id);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -51,7 +51,7 @@
  *
  *   or short form (new, more compact; the module will get the topology from the server directly):
  *
- * <module-name>.CLUSTERSET AUTH {auth}  // the assumption is that all nodes use the same auth
+ * <module-name>.CLUSTERSET [AUTH {pwd}]  // the assumption is that all nodes use the same (or no) password
  */
 
 #define CLUSTERSET_MYID_LONG_FORM_INDEX  6
@@ -61,7 +61,7 @@ static bool IsLongFormClusterSet(int argc) {
 }
 
 static bool IsShortFormClusterSet(int argc) {
-    return argc == 3;
+    return argc == 1 || argc == 3;
 }
 
 #define CLUSTER_INNER_COMMUNICATION_COMMAND xstr(MODULE_NAME)".INNERCOMMUNICATION"
@@ -1099,11 +1099,20 @@ static void SetClusterDataShortForm(RedisModuleString** argv, int argc){
     InitClusterData(clusterCtx.CurrCluster, argv, argc);
     memcpy(clusterCtx.myId, clusterCtx.CurrCluster->myId, REDISMODULE_NODE_ID_LEN + 1);
 
-    size_t index = 1;
-    const char *token = RedisModule_StringPtrLen(argv[index], NULL);
-    RedisModule_Assert(strcasecmp(token, "AUTH") == 0);
-    index++;
-    const char *password = RedisModule_StringPtrLen(argv[index], NULL);
+    const char *password = NULL;
+    switch (argc) {
+    case 1:
+        password = NULL;
+        break;
+    case 3: {
+        const char *token = RedisModule_StringPtrLen(argv[1], NULL);
+        RedisModule_Assert(strcasecmp(token, "AUTH") == 0);
+        password = RedisModule_StringPtrLen(argv[2], NULL);
+        break;
+    }
+    default:
+        RedisModule_Assert(0);
+    }
 
     size_t numNodes;
     char **nodeList = RedisModule_GetClusterNodesList(mr_staticCtx, &numNodes);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -57,7 +57,7 @@
  */
 
 #define CLUSTERSET_MYID_LONG_FORM_INDEX  6
-#define CLUSTERSET_MYID_SHORT_FORM_INDEX 4
+#define CLUSTERSET_MYID_SHORT_FORM_INDEX 2
 
 #define CLUSTER_INNER_COMMUNICATION_COMMAND xstr(MODULE_NAME)".INNERCOMMUNICATION"
 #define CLUSTER_HELLO_COMMAND               xstr(MODULE_NAME)".HELLO"
@@ -942,13 +942,6 @@ static void MR_RefreshClusterData(){
     mr_dictEmpty(clusterCtx.nodesMsgIds, NULL);
 }
 
-static void SetClusterDataShortForm(RedisModuleString** argv, int argc){
-    RedisModule_Log(mr_staticCtx, "notice", "Got cluster set command (short form)");
-
-    clusterCtx.CurrCluster = MR_CALLOC(1, sizeof(*clusterCtx.CurrCluster));
-    clusterCtx.CurrCluster->myIdIndex = CLUSTERSET_MYID_SHORT_FORM_INDEX;
-}
-
 static void GenerateRunId(Cluster* cluster){
     RedisModule_GetRandomHexChars(cluster->runId, RUN_ID_SIZE);
     cluster->runId[RUN_ID_SIZE] = '\0';
@@ -974,6 +967,19 @@ static void SetMyId(Cluster* cluster, RedisModuleString** argv, int argc){
     memset(cluster->myId, '0', zerosPadding);
     memcpy(cluster->myId + zerosPadding, myId, myIdLen);
     cluster->myId[REDISMODULE_NODE_ID_LEN] = '\0';
+}
+
+static void InitClusterData(Cluster* cluster, RedisModuleString** argv, int argc, int myIdIndex){
+    clusterCtx.CurrCluster->clusterSetCommand = MR_ALLOC(sizeof(char*) * argc);
+    clusterCtx.CurrCluster->clusterSetCommandSize = argc;
+    clusterCtx.CurrCluster->clusterSetCommand[0] = MR_STRDUP(CLUSTER_SET_FROM_SHARD_COMMAND);
+    clusterCtx.CurrCluster->myIdIndex = myIdIndex;
+
+    GenerateRunId(clusterCtx.CurrCluster);
+    CopyClusterSetArgs(clusterCtx.CurrCluster, argv, argc);
+    SetMyId(clusterCtx.CurrCluster, argv, argc);
+
+    clusterCtx.CurrCluster->nodes = mr_dictCreate(&mr_dictTypeHeapStrings, NULL);
 }
 
 #define INTERNAL_PASSWORD_MAX_SIZE 100
@@ -1068,22 +1074,76 @@ static int ParseShardEntry(RedisModuleString** argv, int argc, int index,
     return index;
 }
 
+static void SetClusterDataShortForm(RedisModuleString** argv, int argc){
+    RedisModule_Log(mr_staticCtx, "notice", "Got cluster set command (short form)");
+
+    // Verify we have the help we need from the server
+    RedisModule_Assert(RedisModule_ClusterGetNodeSlotRanges != NULL);
+
+    clusterCtx.CurrCluster = MR_CALLOC(1, sizeof(*clusterCtx.CurrCluster));
+    InitClusterData(clusterCtx.CurrCluster, argv, argc, CLUSTERSET_MYID_SHORT_FORM_INDEX);
+    memcpy(clusterCtx.myId, clusterCtx.CurrCluster->myId, REDISMODULE_NODE_ID_LEN + 1);
+
+    size_t index = clusterCtx.CurrCluster->myIdIndex + 1;
+    const char *token = RedisModule_StringPtrLen(argv[index], NULL);
+    RedisModule_Assert(strcasecmp(token, "AUTH") == 0);
+    index++;
+    const char *password = RedisModule_StringPtrLen(argv[index], NULL);
+
+    size_t numNodes;
+    char **nodeList = RedisModule_GetClusterNodesList(mr_staticCtx, &numNodes);
+    if (!nodeList) {
+        RedisModule_Log(mr_staticCtx, "warning", "Failed to get cluster nodes list");
+        return;
+    }
+
+    for (size_t i = 0; i < numNodes; i++) {
+        const char *nodeId = nodeList[i];
+        char ip[INET6_ADDRSTRLEN];  // INET6_ADDRSTRLEN includes the closing '\0'
+        int port, flags;
+
+        if (RedisModule_GetClusterNodeInfo(mr_staticCtx, nodeId, ip, NULL, &port, &flags) != REDISMODULE_OK) {
+            RedisModule_Log(mr_staticCtx, "warning", "Failed to get info for node %s", nodeId);
+            continue;
+        }
+
+        if (!(flags & REDISMODULE_NODE_MASTER)) continue;  // Skip replica nodes
+
+        RedisModule_Assert(MR_GetNode(nodeId) == NULL);
+
+        RedisModuleSlotRangeArray *slots = RedisModule_ClusterGetNodeSlotRanges(mr_staticCtx, nodeId);
+        RedisModule_Assert(slots != NULL && slots->num_ranges > 0);
+        uint16_t minSlot = slots->ranges[0].start;
+        uint16_t maxSlot = slots->ranges[0].end;
+
+        Node* aMasterNode = MR_CreateNode(nodeId, ip, port, password, NULL, minSlot, maxSlot);
+        aMasterNode->isMe = (flags & REDISMODULE_NODE_MYSELF) != 0;
+        if (aMasterNode->isMe) {
+            // fill the fallback single-range; see the comment at the declaration of minSlot and maxSlot
+            clusterCtx.minSlot = minSlot;
+            clusterCtx.maxSlot = maxSlot;
+        }
+
+        for (size_t j = 1; j < slots->num_ranges; j++) {
+            minSlot = slots->ranges[j].start;
+            maxSlot = slots->ranges[j].end;
+            mr_listAddNodeTail(aMasterNode->slotRanges, NewSlotRange(minSlot, maxSlot));
+            for (uint16_t k = minSlot ; k <= maxSlot ; k++)
+                clusterCtx.CurrCluster->slots[k] = aMasterNode;
+        }
+
+        RedisModule_ClusterFreeSlotRanges(mr_staticCtx, slots);
+    }
+
+    RedisModule_FreeClusterNodesList(nodeList);
+}
+
 static void SetClusterDataLongForm(RedisModuleString** argv, int argc){
     RedisModule_Log(mr_staticCtx, "notice", "Got cluster set command (long form)");
 
-    // Initialize
     clusterCtx.CurrCluster = MR_CALLOC(1, sizeof(*clusterCtx.CurrCluster));
-    clusterCtx.CurrCluster->clusterSetCommand = MR_ALLOC(sizeof(char*) * argc);
-    clusterCtx.CurrCluster->clusterSetCommandSize = argc;
-    clusterCtx.CurrCluster->clusterSetCommand[0] = MR_STRDUP(CLUSTER_SET_FROM_SHARD_COMMAND);
-    clusterCtx.CurrCluster->myIdIndex = CLUSTERSET_MYID_LONG_FORM_INDEX;
-
-    GenerateRunId(clusterCtx.CurrCluster);
-    CopyClusterSetArgs(clusterCtx.CurrCluster, argv, argc);
-    SetMyId(clusterCtx.CurrCluster, argv, argc);
+    InitClusterData(clusterCtx.CurrCluster, argv, argc, CLUSTERSET_MYID_LONG_FORM_INDEX);
     memcpy(clusterCtx.myId, clusterCtx.CurrCluster->myId, REDISMODULE_NODE_ID_LEN + 1);
-
-    clusterCtx.CurrCluster->nodes = mr_dictCreate(&mr_dictTypeHeapStrings, NULL);
 
     size_t index = clusterCtx.CurrCluster->myIdIndex + 1;
     const char *token = RedisModule_StringPtrLen(argv[index], NULL);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -51,13 +51,18 @@
  *
  *   or short form (new, more compact; the module will get the topology from the server directly):
  *
- * <module-name>.CLUSTERSET
- * MYID {current_shard_id}
- * AUTH {auth}  // the assumption is that all nodes use the same auth
+ * <module-name>.CLUSTERSET AUTH {auth}  // the assumption is that all nodes use the same auth
  */
 
 #define CLUSTERSET_MYID_LONG_FORM_INDEX  6
-#define CLUSTERSET_MYID_SHORT_FORM_INDEX 2
+
+static bool IsLongFormClusterSet(int argc) {
+    return argc >= 10;
+}
+
+static bool IsShortFormClusterSet(int argc) {
+    return argc == 3;
+}
 
 #define CLUSTER_INNER_COMMUNICATION_COMMAND xstr(MODULE_NAME)".INNERCOMMUNICATION"
 #define CLUSTER_HELLO_COMMAND               xstr(MODULE_NAME)".HELLO"
@@ -143,7 +148,6 @@ typedef struct Cluster {
     mr_dict* nodes;
     Node* slots[MAX_SLOT];
     size_t clusterSetCommandSize;
-    size_t myIdIndex;  // in the clusterSetCommand[]
     char** clusterSetCommand;
     char runId[RUN_ID_SIZE + 1];
 }Cluster;
@@ -388,12 +392,16 @@ static void MR_ClusterResendHelloMessage(void* ctx){
         return;
     }
     if(n->sendClusterTopologyOnNextConnect && clusterCtx.CurrCluster->clusterSetCommand){
-        RedisModule_Log(mr_staticCtx, "notice", "Sending cluster topology to %s (%s:%d) on rg.hello retry", n->id, n->ip, n->port);
-        size_t myIdIndex = clusterCtx.CurrCluster->myIdIndex;
-        clusterCtx.CurrCluster->clusterSetCommand[myIdIndex] = MR_STRDUP(n->id);
+        bool isLongForm = IsLongFormClusterSet(clusterCtx.CurrCluster->clusterSetCommandSize);
+        RedisModule_Log(mr_staticCtx, "notice", "Sending cluster (%s form) topology to %s (%s:%d) on rg.hello retry",
+                isLongForm ? "long" : "short", n->id, n->ip, n->port);
+        if (isLongForm)
+            clusterCtx.CurrCluster->clusterSetCommand[CLUSTERSET_MYID_LONG_FORM_INDEX] = MR_STRDUP(n->id);
         redisAsyncCommandArgv(n->c, NULL, NULL, clusterCtx.CurrCluster->clusterSetCommandSize, (const char**)clusterCtx.CurrCluster->clusterSetCommand, NULL);
-        MR_FREE(clusterCtx.CurrCluster->clusterSetCommand[myIdIndex]);
-        clusterCtx.CurrCluster->clusterSetCommand[myIdIndex] = NULL;
+        if (isLongForm) {
+            MR_FREE(clusterCtx.CurrCluster->clusterSetCommand[CLUSTERSET_MYID_LONG_FORM_INDEX]);
+            clusterCtx.CurrCluster->clusterSetCommand[CLUSTERSET_MYID_LONG_FORM_INDEX] = NULL;
+        }
         n->sendClusterTopologyOnNextConnect = false;
     }
 
@@ -690,12 +698,16 @@ static void MR_OnConnectCallback(const struct redisAsyncContext* c, int status){
     SendAuthCommandIfNeeded(c, n);
 
     if(n->sendClusterTopologyOnNextConnect && clusterCtx.CurrCluster->clusterSetCommand){
-        RedisModule_Log(mr_staticCtx, "notice", "Sending cluster topology to %s (%s:%d) after reconnect", n->id, n->ip, n->port);
-        size_t myIdIndex = clusterCtx.CurrCluster->myIdIndex;
-        clusterCtx.CurrCluster->clusterSetCommand[myIdIndex] = MR_STRDUP(n->id);
+        bool isLongForm = IsLongFormClusterSet(clusterCtx.CurrCluster->clusterSetCommandSize);
+        RedisModule_Log(mr_staticCtx, "notice", "Sending cluster (%s form) topology to %s (%s:%d) on after reconnect",
+                isLongForm ? "long" : "short", n->id, n->ip, n->port);
+        if (isLongForm)
+            clusterCtx.CurrCluster->clusterSetCommand[CLUSTERSET_MYID_LONG_FORM_INDEX] = MR_STRDUP(n->id);
         redisAsyncCommandArgv((redisAsyncContext*)c, NULL, NULL, clusterCtx.CurrCluster->clusterSetCommandSize, (const char**)clusterCtx.CurrCluster->clusterSetCommand, NULL);
-        MR_FREE(clusterCtx.CurrCluster->clusterSetCommand[myIdIndex]);
-        clusterCtx.CurrCluster->clusterSetCommand[myIdIndex] = NULL;
+        if (isLongForm) {
+            MR_FREE(clusterCtx.CurrCluster->clusterSetCommand[CLUSTERSET_MYID_LONG_FORM_INDEX]);
+            clusterCtx.CurrCluster->clusterSetCommand[CLUSTERSET_MYID_LONG_FORM_INDEX] = NULL;
+        }
         n->sendClusterTopologyOnNextConnect = false;
     }
     redisAsyncCommand((redisAsyncContext*)c, MR_HelloResponseArrived, n, CLUSTER_HELLO_COMMAND);
@@ -949,7 +961,7 @@ static void GenerateRunId(Cluster* cluster){
 
 static void CopyClusterSetArgs(Cluster* cluster, RedisModuleString** argv, int argc){
     for(int i = 1 ; i < argc ; ++i){
-        if(i == cluster->myIdIndex){
+        if (IsLongFormClusterSet(argc) && i == CLUSTERSET_MYID_LONG_FORM_INDEX) {
             cluster->clusterSetCommand[i] = NULL;
             continue;
         }
@@ -959,9 +971,13 @@ static void CopyClusterSetArgs(Cluster* cluster, RedisModuleString** argv, int a
 }
 
 static void SetMyId(Cluster* cluster, RedisModuleString** argv, int argc){
-    RedisModule_Assert(cluster->myIdIndex < argc);
-    size_t myIdLen;
-    const char* myId = RedisModule_StringPtrLen(argv[cluster->myIdIndex], &myIdLen);
+    const char* myId = RedisModule_GetMyClusterID();
+    size_t myIdLen = REDISMODULE_NODE_ID_LEN;
+    if (IsLongFormClusterSet(argc)) {
+        RedisModule_Assert(CLUSTERSET_MYID_LONG_FORM_INDEX < argc);
+        myId = RedisModule_StringPtrLen(argv[CLUSTERSET_MYID_LONG_FORM_INDEX], &myIdLen);
+    }
+
     cluster->myId = MR_ALLOC(REDISMODULE_NODE_ID_LEN + 1);
     size_t zerosPadding = REDISMODULE_NODE_ID_LEN - myIdLen;
     memset(cluster->myId, '0', zerosPadding);
@@ -969,11 +985,10 @@ static void SetMyId(Cluster* cluster, RedisModuleString** argv, int argc){
     cluster->myId[REDISMODULE_NODE_ID_LEN] = '\0';
 }
 
-static void InitClusterData(Cluster* cluster, RedisModuleString** argv, int argc, int myIdIndex){
+static void InitClusterData(Cluster* cluster, RedisModuleString** argv, int argc){
     clusterCtx.CurrCluster->clusterSetCommand = MR_ALLOC(sizeof(char*) * argc);
     clusterCtx.CurrCluster->clusterSetCommandSize = argc;
     clusterCtx.CurrCluster->clusterSetCommand[0] = MR_STRDUP(CLUSTER_SET_FROM_SHARD_COMMAND);
-    clusterCtx.CurrCluster->myIdIndex = myIdIndex;
 
     GenerateRunId(clusterCtx.CurrCluster);
     CopyClusterSetArgs(clusterCtx.CurrCluster, argv, argc);
@@ -1081,10 +1096,10 @@ static void SetClusterDataShortForm(RedisModuleString** argv, int argc){
     RedisModule_Assert(RedisModule_ClusterGetNodeSlotRanges != NULL);
 
     clusterCtx.CurrCluster = MR_CALLOC(1, sizeof(*clusterCtx.CurrCluster));
-    InitClusterData(clusterCtx.CurrCluster, argv, argc, CLUSTERSET_MYID_SHORT_FORM_INDEX);
+    InitClusterData(clusterCtx.CurrCluster, argv, argc);
     memcpy(clusterCtx.myId, clusterCtx.CurrCluster->myId, REDISMODULE_NODE_ID_LEN + 1);
 
-    size_t index = clusterCtx.CurrCluster->myIdIndex + 1;
+    size_t index = 1;
     const char *token = RedisModule_StringPtrLen(argv[index], NULL);
     RedisModule_Assert(strcasecmp(token, "AUTH") == 0);
     index++;
@@ -1142,10 +1157,10 @@ static void SetClusterDataLongForm(RedisModuleString** argv, int argc){
     RedisModule_Log(mr_staticCtx, "notice", "Got cluster set command (long form)");
 
     clusterCtx.CurrCluster = MR_CALLOC(1, sizeof(*clusterCtx.CurrCluster));
-    InitClusterData(clusterCtx.CurrCluster, argv, argc, CLUSTERSET_MYID_LONG_FORM_INDEX);
+    InitClusterData(clusterCtx.CurrCluster, argv, argc);
     memcpy(clusterCtx.myId, clusterCtx.CurrCluster->myId, REDISMODULE_NODE_ID_LEN + 1);
 
-    size_t index = clusterCtx.CurrCluster->myIdIndex + 1;
+    size_t index = CLUSTERSET_MYID_LONG_FORM_INDEX + 1;
     const char *token = RedisModule_StringPtrLen(argv[index], NULL);
     bool hasReplication = strcasecmp(token, "HASREPLICATION") == 0;
     if (hasReplication) {  // skip this token; we ignore it
@@ -1204,12 +1219,12 @@ static void SetClusterDataLongForm(RedisModuleString** argv, int argc){
 }
 
 static void MR_SetClusterData(RedisModuleString** argv, int argc){
-    if(clusterCtx.CurrCluster){
+    if(clusterCtx.CurrCluster)
         MR_ClusterFree();
-    }
-    if (argc >= 10)
+
+    if (IsLongFormClusterSet(argc))
         SetClusterDataLongForm(argv, argc);
-    else if (argc == 5)
+    else if (IsShortFormClusterSet(argc))
         SetClusterDataShortForm(argv, argc);
     else
         RedisModule_Log(mr_staticCtx, "warning", "Could not parse cluster set arguments");
@@ -1264,7 +1279,7 @@ static int MR_ClusterRefresh(RedisModuleCtx *ctx, RedisModuleString **argv, int 
 }
 
 static int MR_ClusterSet(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
-    if(argc < 10 && argc != 5){  // Long forms are >= 10; short forms are 5
+    if (!(IsShortFormClusterSet(argc) || IsLongFormClusterSet(argc))) {
         RedisModule_ReplyWithError(ctx, "Could not parse cluster set arguments");
         return REDISMODULE_OK;
     }
@@ -1278,7 +1293,7 @@ static int MR_ClusterSet(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
 }
 
 static int MR_ClusterSetFromShard(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
-    if(argc < 10){
+    if (!(IsShortFormClusterSet(argc) || IsLongFormClusterSet(argc))) {
         RedisModule_ReplyWithError(ctx, "Could not parse cluster set arguments");
         return REDISMODULE_OK;
     }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1142,6 +1142,11 @@ static void SetClusterDataShortForm(RedisModuleString** argv, int argc){
         }
 
         Node* aMasterNode = MR_CreateNode(nodeId, ip, port, password, NULL, minSlot, maxSlot);
+        // Note that MR_CreateNode has already set the isMe bool, but since here we have the flags
+        // which are the "formal" way to know if this node is me, we override it here.
+        // Basically they should have the same outcome, but given the various ways we name a node
+        // (e.g., in RE they are the shard uids, left-padded with 0s), it's safer not to assert
+        // that they are the same and use the flags as the actual true value.
         aMasterNode->isMe = (flags & REDISMODULE_NODE_MYSELF) != 0;
         if (aMasterNode->isMe) {
             // fill the fallback single-range; see the comment at the declaration of minSlot and maxSlot

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1149,8 +1149,10 @@ static void SetClusterDataShortForm(RedisModuleString** argv, int argc){
 
         RedisModule_ClusterFreeSlotRanges(mr_staticCtx, slots);
     }
-
     RedisModule_FreeClusterNodesList(nodeList);
+
+    clusterCtx.clusterSize = mr_dictSize(clusterCtx.CurrCluster->nodes);
+    mr_dictEmpty(clusterCtx.nodesMsgIds, NULL);
 }
 
 static void SetClusterDataLongForm(RedisModuleString** argv, int argc){

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -31,9 +31,33 @@
 
 #define RETRY_INTERVAL 1000 // 1 second
 #define MSG_MAX_RETRIES 3
-#define CLUSTER_SET_MY_ID_INDEX 6
 #define MAX_SLOT 16384
 #define RUN_ID_SIZE 40
+
+/*
+ * The CLUSTERSET command can come in a long form (legacy, very explicit):
+ *
+ * <module-name>.CLUSTERSET
+ * HASHFUNC {hashing_function}
+ * NUMSLOTS {number_of_slots}
+ * MYID {current_shard_id}
+ * [HASREPLICATION]
+ * RANGES {num_of_ranges}
+ *   { SHARD {shard_id}
+ *     [SLOTRANGE {start_slot} {end_slot}]
+ *     ADDR {auth@ip:port} [UNIXADDR {unixsock}]
+ *     [MASTER]
+ *   }
+ *
+ *   or short form (new, more compact; the module will get the topology from the server directly):
+ *
+ * <module-name>.CLUSTERSET
+ * MYID {current_shard_id}
+ * AUTH {auth}  // the assumption is that all nodes use the same auth
+ */
+
+#define CLUSTERSET_MYID_LONG_FORM_INDEX  6
+#define CLUSTERSET_MYID_SHORT_FORM_INDEX 4
 
 #define CLUSTER_INNER_COMMUNICATION_COMMAND xstr(MODULE_NAME)".INNERCOMMUNICATION"
 #define CLUSTER_HELLO_COMMAND               xstr(MODULE_NAME)".HELLO"
@@ -119,6 +143,7 @@ typedef struct Cluster {
     mr_dict* nodes;
     Node* slots[MAX_SLOT];
     size_t clusterSetCommandSize;
+    size_t myIdIndex;  // in the clusterSetCommand[]
     char** clusterSetCommand;
     char runId[RUN_ID_SIZE + 1];
 }Cluster;
@@ -364,10 +389,11 @@ static void MR_ClusterResendHelloMessage(void* ctx){
     }
     if(n->sendClusterTopologyOnNextConnect && clusterCtx.CurrCluster->clusterSetCommand){
         RedisModule_Log(mr_staticCtx, "notice", "Sending cluster topology to %s (%s:%d) on rg.hello retry", n->id, n->ip, n->port);
-        clusterCtx.CurrCluster->clusterSetCommand[CLUSTER_SET_MY_ID_INDEX] = MR_STRDUP(n->id);
+        size_t myIdIndex = clusterCtx.CurrCluster->myIdIndex;
+        clusterCtx.CurrCluster->clusterSetCommand[myIdIndex] = MR_STRDUP(n->id);
         redisAsyncCommandArgv(n->c, NULL, NULL, clusterCtx.CurrCluster->clusterSetCommandSize, (const char**)clusterCtx.CurrCluster->clusterSetCommand, NULL);
-        MR_FREE(clusterCtx.CurrCluster->clusterSetCommand[CLUSTER_SET_MY_ID_INDEX]);
-        clusterCtx.CurrCluster->clusterSetCommand[CLUSTER_SET_MY_ID_INDEX] = NULL;
+        MR_FREE(clusterCtx.CurrCluster->clusterSetCommand[myIdIndex]);
+        clusterCtx.CurrCluster->clusterSetCommand[myIdIndex] = NULL;
         n->sendClusterTopologyOnNextConnect = false;
     }
 
@@ -665,10 +691,11 @@ static void MR_OnConnectCallback(const struct redisAsyncContext* c, int status){
 
     if(n->sendClusterTopologyOnNextConnect && clusterCtx.CurrCluster->clusterSetCommand){
         RedisModule_Log(mr_staticCtx, "notice", "Sending cluster topology to %s (%s:%d) after reconnect", n->id, n->ip, n->port);
-        clusterCtx.CurrCluster->clusterSetCommand[CLUSTER_SET_MY_ID_INDEX] = MR_STRDUP(n->id);
+        size_t myIdIndex = clusterCtx.CurrCluster->myIdIndex;
+        clusterCtx.CurrCluster->clusterSetCommand[myIdIndex] = MR_STRDUP(n->id);
         redisAsyncCommandArgv((redisAsyncContext*)c, NULL, NULL, clusterCtx.CurrCluster->clusterSetCommandSize, (const char**)clusterCtx.CurrCluster->clusterSetCommand, NULL);
-        MR_FREE(clusterCtx.CurrCluster->clusterSetCommand[CLUSTER_SET_MY_ID_INDEX]);
-        clusterCtx.CurrCluster->clusterSetCommand[CLUSTER_SET_MY_ID_INDEX] = NULL;
+        MR_FREE(clusterCtx.CurrCluster->clusterSetCommand[myIdIndex]);
+        clusterCtx.CurrCluster->clusterSetCommand[myIdIndex] = NULL;
         n->sendClusterTopologyOnNextConnect = false;
     }
     redisAsyncCommand((redisAsyncContext*)c, MR_HelloResponseArrived, n, CLUSTER_HELLO_COMMAND);
@@ -915,58 +942,158 @@ static void MR_RefreshClusterData(){
     mr_dictEmpty(clusterCtx.nodesMsgIds, NULL);
 }
 
-static void MR_SetClusterData(RedisModuleString** argv, int argc){
-    if(clusterCtx.CurrCluster){
-        MR_ClusterFree();
-    }
-
-    RedisModule_Log(mr_staticCtx, "notice", "Got cluster set command");
-
-    if(argc < 10){
-        RedisModule_Log(mr_staticCtx, "warning", "Could not parse cluster set arguments");
-        return;
-    }
+static void SetClusterDataShortForm(RedisModuleString** argv, int argc){
+    RedisModule_Log(mr_staticCtx, "notice", "Got cluster set command (short form)");
 
     clusterCtx.CurrCluster = MR_CALLOC(1, sizeof(*clusterCtx.CurrCluster));
+    clusterCtx.CurrCluster->myIdIndex = CLUSTERSET_MYID_SHORT_FORM_INDEX;
+}
 
-    // generate runID
-    RedisModule_GetRandomHexChars(clusterCtx.CurrCluster->runId, RUN_ID_SIZE);
-    clusterCtx.CurrCluster->runId[RUN_ID_SIZE] = '\0';
+static void GenerateRunId(Cluster* cluster){
+    RedisModule_GetRandomHexChars(cluster->runId, RUN_ID_SIZE);
+    cluster->runId[RUN_ID_SIZE] = '\0';
+}
 
-    clusterCtx.CurrCluster->clusterSetCommand = MR_ALLOC(sizeof(char*) * argc);
-    clusterCtx.CurrCluster->clusterSetCommandSize = argc;
-
-    clusterCtx.CurrCluster->clusterSetCommand[0] = MR_STRDUP(CLUSTER_SET_FROM_SHARD_COMMAND);
-
+static void CopyClusterSetArgs(Cluster* cluster, RedisModuleString** argv, int argc){
     for(int i = 1 ; i < argc ; ++i){
-        if(i == CLUSTER_SET_MY_ID_INDEX){
-            clusterCtx.CurrCluster->clusterSetCommand[i] = NULL;
+        if(i == cluster->myIdIndex){
+            cluster->clusterSetCommand[i] = NULL;
             continue;
         }
         const char* arg = RedisModule_StringPtrLen(argv[i], NULL);
-        clusterCtx.CurrCluster->clusterSetCommand[i] = MR_STRDUP(arg);
+        cluster->clusterSetCommand[i] = MR_STRDUP(arg);
+    }
+}
+
+static void SetMyId(Cluster* cluster, RedisModuleString** argv, int argc){
+    RedisModule_Assert(cluster->myIdIndex < argc);
+    size_t myIdLen;
+    const char* myId = RedisModule_StringPtrLen(argv[cluster->myIdIndex], &myIdLen);
+    cluster->myId = MR_ALLOC(REDISMODULE_NODE_ID_LEN + 1);
+    size_t zerosPadding = REDISMODULE_NODE_ID_LEN - myIdLen;
+    memset(cluster->myId, '0', zerosPadding);
+    memcpy(cluster->myId + zerosPadding, myId, myIdLen);
+    cluster->myId[REDISMODULE_NODE_ID_LEN] = '\0';
+}
+
+#define INTERNAL_PASSWORD_MAX_SIZE 100
+
+// Parse a SHARD entry into the output arguments and return the index of the last parsed token
+static int ParseShardEntry(RedisModuleString** argv, int argc, int index,
+                           char realId[],
+                           char ip[], unsigned short* port, char password[],
+                           long long* minSlot, long long* maxSlot,
+                           bool* shouldSkip){
+    *shouldSkip = false;
+    const char* token;
+
+    RedisModule_Assert(index < argc);
+    token = RedisModule_StringPtrLen(argv[index], NULL);
+    RedisModule_Assert(strcasecmp(token, "SHARD") == 0);
+
+    index++;
+    RedisModule_Assert(index < argc);
+    size_t shardIdLen;
+    const char* shardId = RedisModule_StringPtrLen(argv[index], &shardIdLen);
+    size_t zerosPadding = REDISMODULE_NODE_ID_LEN - shardIdLen;
+    memset(realId, '0', zerosPadding);
+    memcpy(realId + zerosPadding, shardId, shardIdLen);
+    realId[REDISMODULE_NODE_ID_LEN] = '\0';
+    index++;
+
+    *minSlot = 0;
+    *maxSlot = -1;  // min > max indicates a no-hslots range (i.e., used for slotless shards)
+    RedisModule_Assert(index < argc);
+    token = RedisModule_StringPtrLen(argv[index], NULL);
+    if (strcasecmp(token, "SLOTRANGE") == 0) {
+        index++;
+        RedisModule_Assert(index < argc);
+        RedisModule_Assert(RedisModule_StringToLongLong(argv[index++], minSlot) == REDISMODULE_OK);
+        RedisModule_Assert(index < argc);
+        RedisModule_Assert(RedisModule_StringToLongLong(argv[index++], maxSlot) == REDISMODULE_OK);
     }
 
-    size_t myIdLen;
-    RedisModule_Assert(CLUSTER_SET_MY_ID_INDEX < argc);
-    const char* myId = RedisModule_StringPtrLen(argv[CLUSTER_SET_MY_ID_INDEX], &myIdLen);
-    clusterCtx.CurrCluster->myId = MR_ALLOC(REDISMODULE_NODE_ID_LEN + 1);
-    size_t zerosPadding = REDISMODULE_NODE_ID_LEN - myIdLen;
-    memset(clusterCtx.CurrCluster->myId, '0', zerosPadding);
-    memcpy(clusterCtx.CurrCluster->myId + zerosPadding, myId, myIdLen);
-    clusterCtx.CurrCluster->myId[REDISMODULE_NODE_ID_LEN] = '\0';
+    RedisModule_Assert(index < argc);
+    token = RedisModule_StringPtrLen(argv[index], NULL);
+    RedisModule_Assert(strcasecmp(token, "ADDR") == 0);
+    index++;
+
+    RedisModule_Assert(index < argc);
+    const char* addr = RedisModule_StringPtrLen(argv[index++], NULL);
+    char* passEnd = strstr(addr, "@");
+    RedisModule_Assert(passEnd != NULL);
+    size_t passSize = passEnd - addr;
+    RedisModule_Assert(passSize < INTERNAL_PASSWORD_MAX_SIZE);
+    memcpy(password, addr, passSize);
+    password[passSize] = '\0';
+
+    addr = passEnd + 1;
+
+    if (addr[0] == '[') {
+        addr += 1; /* skip ipv6 opener `[` */
+    }
+
+    /* Find last `:` */
+    const char *ipEnd = strrchr(addr, ':');
+    RedisModule_Assert(ipEnd != NULL);
+
+    size_t ipSize = ipEnd - addr;
+    if (addr[ipSize - 1] == ']') {
+        --ipSize; /* Skip ipv6 closer `]` */
+    }
+    RedisModule_Assert(ipSize < INET6_ADDRSTRLEN);
+
+    memcpy(ip, addr, ipSize);
+    ip[ipSize] = '\0';
+    *port = (unsigned short)atoi(ipEnd + 1);
+
+    if (index >= argc) {
+        *shouldSkip = true;
+        return index;
+    }
+    token = RedisModule_StringPtrLen(argv[index], NULL);
+    if (strcasecmp(token, "UNIXADDR") == 0)
+        index += 2; // Ignore it and its value
+
+    if (index >= argc) {
+        *shouldSkip = true;
+        return index;
+    }
+    token = RedisModule_StringPtrLen(argv[index], NULL);
+    if (strcasecmp(token, "MASTER") != 0) {
+        *shouldSkip = true; // Ignore non-master nodes
+        return index;
+    }
+
+    return index;
+}
+
+static void SetClusterDataLongForm(RedisModuleString** argv, int argc){
+    RedisModule_Log(mr_staticCtx, "notice", "Got cluster set command (long form)");
+
+    // Initialize
+    clusterCtx.CurrCluster = MR_CALLOC(1, sizeof(*clusterCtx.CurrCluster));
+    clusterCtx.CurrCluster->clusterSetCommand = MR_ALLOC(sizeof(char*) * argc);
+    clusterCtx.CurrCluster->clusterSetCommandSize = argc;
+    clusterCtx.CurrCluster->clusterSetCommand[0] = MR_STRDUP(CLUSTER_SET_FROM_SHARD_COMMAND);
+    clusterCtx.CurrCluster->myIdIndex = CLUSTERSET_MYID_LONG_FORM_INDEX;
+
+    GenerateRunId(clusterCtx.CurrCluster);
+    CopyClusterSetArgs(clusterCtx.CurrCluster, argv, argc);
+    SetMyId(clusterCtx.CurrCluster, argv, argc);
     memcpy(clusterCtx.myId, clusterCtx.CurrCluster->myId, REDISMODULE_NODE_ID_LEN + 1);
 
     clusterCtx.CurrCluster->nodes = mr_dictCreate(&mr_dictTypeHeapStrings, NULL);
 
-    size_t index = 7;
+    size_t index = clusterCtx.CurrCluster->myIdIndex + 1;
     const char *token = RedisModule_StringPtrLen(argv[index], NULL);
     bool hasReplication = strcasecmp(token, "HASREPLICATION") == 0;
-    if (hasReplication) {
+    if (hasReplication) {  // skip this token; we ignore it
         index++;
         RedisModule_Assert(index < argc);
         token = RedisModule_StringPtrLen(argv[index], NULL);
     }
+
     RedisModule_Assert(strcasecmp(token, "RANGES") == 0);
     index++;
     RedisModule_Assert(index < argc);
@@ -978,79 +1105,20 @@ static void MR_SetClusterData(RedisModuleString** argv, int argc){
     index++;
 
     for (size_t j = 0 ; j < numOfRanges ; ++j){
-        RedisModule_Assert(index < argc);
-        token = RedisModule_StringPtrLen(argv[index], NULL);
-        RedisModule_Assert(strcasecmp(token, "SHARD") == 0);
-
-        index++;
-        RedisModule_Assert(index < argc);
-        size_t shardIdLen;
-        const char* shardId = RedisModule_StringPtrLen(argv[index], &shardIdLen);
         char realId[REDISMODULE_NODE_ID_LEN + 1];
-        size_t zerosPadding = REDISMODULE_NODE_ID_LEN - shardIdLen;
-        memset(realId, '0', zerosPadding);
-        memcpy(realId + zerosPadding, shardId, shardIdLen);
-        realId[REDISMODULE_NODE_ID_LEN] = '\0';
-        index++;
+        char ip[INET6_ADDRSTRLEN];  // INET6_ADDRSTRLEN includes the closing '\0'
+        unsigned short port;
+        char password[INTERNAL_PASSWORD_MAX_SIZE + 1];
+        long long minSlot, maxSlot;
+        bool shouldSkip;
 
-        long long minSlot = 0, maxSlot = -1;  // min > max indicates a no-hslots range (i.e., used for slotless shards)
-        RedisModule_Assert(index < argc);
-        token = RedisModule_StringPtrLen(argv[index], NULL);
-        if (strcasecmp(token, "SLOTRANGE") == 0) {
-            index++;
-            RedisModule_Assert(index < argc);
-            RedisModule_Assert(RedisModule_StringToLongLong(argv[index++], &minSlot) == REDISMODULE_OK);
-            RedisModule_Assert(index < argc);
-            RedisModule_Assert(RedisModule_StringToLongLong(argv[index++], &maxSlot) == REDISMODULE_OK);
-        }
-
-        RedisModule_Assert(index < argc);
-        token = RedisModule_StringPtrLen(argv[index], NULL);
-        RedisModule_Assert(strcasecmp(token, "ADDR") == 0);
-        index++;
-
-        RedisModule_Assert(index < argc);
-        const char* addr = RedisModule_StringPtrLen(argv[index++], NULL);
-        char* passEnd = strstr(addr, "@");
-        RedisModule_Assert(passEnd != NULL);
-        size_t passSize = passEnd - addr;
-        char password[passSize + 1];
-        memcpy(password, addr, passSize);
-        password[passSize] = '\0';
-
-        addr = passEnd + 1;
-
-        if (addr[0] == '[') {
-            addr += 1; /* skip ipv6 opener `[` */
-        }
-
-        /* Find last `:` */
-        const char *ipEnd = strrchr(addr, ':');
-        RedisModule_Assert(ipEnd != NULL);
-
-        size_t ipSize = ipEnd - addr;
-        if (addr[ipSize - 1] == ']') {
-            --ipSize; /* Skip ipv6 closer `]` */
-        }
-
-        char ip[ipSize + 1];
-        memcpy(ip, addr, ipSize);
-        ip[ipSize] = '\0';
-        unsigned short port = (unsigned short)atoi(ipEnd + 1);
-
+        index = ParseShardEntry(argv, argc, index, realId, ip, &port, password, &minSlot, &maxSlot, &shouldSkip);
         if (index >= argc)
             break;
-        token = RedisModule_StringPtrLen(argv[index], NULL);
-        if (strcasecmp(token, "UNIXADDR") == 0)
-            index += 2; // Ignore it and its value
+        if (shouldSkip)
+            continue;
 
-        if (index >= argc)
-            break;
-        token = RedisModule_StringPtrLen(argv[index], NULL);
-        if (strcasecmp(token, "MASTER") != 0)
-            continue; // Ignore non-master nodes
-
-        // All info is parsed, create a new node or update an existing one
+        // Create a new node or update an existing one
         Node* aMasterNode = MR_GetNode(realId);
         if(!aMasterNode){
             aMasterNode = MR_CreateNode(realId, ip, port, password, NULL, minSlot, maxSlot);
@@ -1064,6 +1132,7 @@ static void MR_SetClusterData(RedisModuleString** argv, int argc){
         }
 
         if (aMasterNode->isMe) {
+            // fill the fallback single-range; see the comment at the declaration of minSlot and maxSlot
             clusterCtx.minSlot = minSlot;
             clusterCtx.maxSlot = maxSlot;
         }
@@ -1072,6 +1141,18 @@ static void MR_SetClusterData(RedisModuleString** argv, int argc){
     }
     clusterCtx.clusterSize = mr_dictSize(clusterCtx.CurrCluster->nodes);
     mr_dictEmpty(clusterCtx.nodesMsgIds, NULL);
+}
+
+static void MR_SetClusterData(RedisModuleString** argv, int argc){
+    if(clusterCtx.CurrCluster){
+        MR_ClusterFree();
+    }
+    if (argc >= 10)
+        SetClusterDataLongForm(argv, argc);
+    else if (argc == 5)
+        SetClusterDataShortForm(argv, argc);
+    else
+        RedisModule_Log(mr_staticCtx, "warning", "Could not parse cluster set arguments");
 }
 
 /* runs in the event loop so its safe to update cluster
@@ -1123,7 +1204,7 @@ static int MR_ClusterRefresh(RedisModuleCtx *ctx, RedisModuleString **argv, int 
 }
 
 static int MR_ClusterSet(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
-    if(argc < 10){
+    if(argc < 10 && argc != 5){  // Long forms are >= 10; short forms are 5
         RedisModule_ReplyWithError(ctx, "Could not parse cluster set arguments");
         return REDISMODULE_OK;
     }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -31,7 +31,7 @@
 
 #define RETRY_INTERVAL 1000 // 1 second
 #define MSG_MAX_RETRIES 3
-#define MAX_SLOT 16384
+#define NUMBER_OF_SLOTS 16384
 #define RUN_ID_SIZE 40
 
 /*
@@ -146,7 +146,7 @@ typedef struct Node{
 typedef struct Cluster {
     char* myId;
     mr_dict* nodes;
-    Node* slots[MAX_SLOT];
+    Node* slots[NUMBER_OF_SLOTS];
     size_t clusterSetCommandSize;
     char** clusterSetCommand;
     char runId[RUN_ID_SIZE + 1];
@@ -1136,9 +1136,13 @@ static void SetClusterDataShortForm(RedisModuleString** argv, int argc){
         RedisModule_Assert(MR_GetNode(nodeId) == NULL);
 
         RedisModuleSlotRangeArray *slots = RedisModule_GetClusterNodeSlotRanges(mr_staticCtx, nodeId);
-        RedisModule_Assert(slots != NULL && slots->num_ranges > 0);
-        uint16_t minSlot = slots->ranges[0].start;
-        uint16_t maxSlot = slots->ranges[0].end;
+        RedisModule_Assert(slots != NULL);
+        uint16_t minSlot = 0;
+        uint16_t maxSlot = NUMBER_OF_SLOTS - 1;
+        if (slots->num_ranges > 0) {
+            minSlot = slots->ranges[0].start;
+            maxSlot = slots->ranges[0].end;
+        }
 
         Node* aMasterNode = MR_CreateNode(nodeId, ip, port, password, NULL, minSlot, maxSlot);
         aMasterNode->isMe = (flags & REDISMODULE_NODE_MYSELF) != 0;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1159,7 +1159,7 @@ static void SetClusterDataShortForm(RedisModuleString** argv, int argc){
             maxSlot = slots->ranges[j].end;
             if (j > 0)  // The 0 case is handled by the MR_CreateNode() above
                 mr_listAddNodeTail(aMasterNode->slotRanges, NewSlotRange(minSlot, maxSlot));
-            for (uint16_t k = minSlot ; k <= maxSlot ; k++)
+            for (int k = minSlot ; k <= maxSlot ; k++)
                 clusterCtx.CurrCluster->slots[k] = aMasterNode;
         }
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1093,7 +1093,7 @@ static void SetClusterDataShortForm(RedisModuleString** argv, int argc){
     RedisModule_Log(mr_staticCtx, "notice", "Got cluster set command (short form)");
 
     // Verify we have the help we need from the server
-    RedisModule_Assert(RedisModule_ClusterGetNodeSlotRanges != NULL);
+    RedisModule_Assert(RedisModule_GetClusterNodeSlotRanges != NULL);
 
     clusterCtx.CurrCluster = MR_CALLOC(1, sizeof(*clusterCtx.CurrCluster));
     InitClusterData(clusterCtx.CurrCluster, argv, argc);
@@ -1126,7 +1126,7 @@ static void SetClusterDataShortForm(RedisModuleString** argv, int argc){
 
         RedisModule_Assert(MR_GetNode(nodeId) == NULL);
 
-        RedisModuleSlotRangeArray *slots = RedisModule_ClusterGetNodeSlotRanges(mr_staticCtx, nodeId);
+        RedisModuleSlotRangeArray *slots = RedisModule_GetClusterNodeSlotRanges(mr_staticCtx, nodeId);
         RedisModule_Assert(slots != NULL && slots->num_ranges > 0);
         uint16_t minSlot = slots->ranges[0].start;
         uint16_t maxSlot = slots->ranges[0].end;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1137,8 +1137,7 @@ static void SetClusterDataShortForm(RedisModuleString** argv, int argc){
 
         RedisModuleSlotRangeArray *slots = RedisModule_GetClusterNodeSlotRanges(mr_staticCtx, nodeId);
         RedisModule_Assert(slots != NULL);
-        uint16_t minSlot = 0;
-        uint16_t maxSlot = NUMBER_OF_SLOTS - 1;
+        long long minSlot = 0, maxSlot = -1;  // min > max indicates a no-hslots range (i.e., used for slotless shards)
         if (slots->num_ranges > 0) {
             minSlot = slots->ranges[0].start;
             maxSlot = slots->ranges[0].end;

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1356,6 +1356,7 @@ REDISMODULE_API const char *(*RedisModule_ClusterCanonicalKeyNameInSlot)(unsigne
 REDISMODULE_API int (*RedisModule_ClusterCanAccessKeysInSlot)(int slot) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ClusterPropagateForSlotMigration)(RedisModuleCtx *ctx, const char *cmdname, const char *fmt, ...) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleSlotRangeArray *(*RedisModule_ClusterGetLocalSlotRanges)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleSlotRangeArray *(*RedisModule_ClusterGetNodeSlotRanges)(RedisModuleCtx *ctx, const char *id) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_ClusterFreeSlotRanges)(RedisModuleCtx *ctx, RedisModuleSlotRangeArray *slots) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ExportSharedAPI)(RedisModuleCtx *ctx, const char *apiname, void *func) REDISMODULE_ATTR;
 REDISMODULE_API void * (*RedisModule_GetSharedAPI)(RedisModuleCtx *ctx, const char *apiname) REDISMODULE_ATTR;
@@ -1756,6 +1757,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(ClusterCanAccessKeysInSlot);
     REDISMODULE_GET_API(ClusterPropagateForSlotMigration);
     REDISMODULE_GET_API(ClusterGetLocalSlotRanges);
+    REDISMODULE_GET_API(ClusterGetNodeSlotRanges);
     REDISMODULE_GET_API(ClusterFreeSlotRanges);
     REDISMODULE_GET_API(ExportSharedAPI);
     REDISMODULE_GET_API(GetSharedAPI);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1356,7 +1356,7 @@ REDISMODULE_API const char *(*RedisModule_ClusterCanonicalKeyNameInSlot)(unsigne
 REDISMODULE_API int (*RedisModule_ClusterCanAccessKeysInSlot)(int slot) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ClusterPropagateForSlotMigration)(RedisModuleCtx *ctx, const char *cmdname, const char *fmt, ...) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleSlotRangeArray *(*RedisModule_ClusterGetLocalSlotRanges)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleSlotRangeArray *(*RedisModule_ClusterGetNodeSlotRanges)(RedisModuleCtx *ctx, const char *id) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleSlotRangeArray *(*RedisModule_GetClusterNodeSlotRanges)(RedisModuleCtx *ctx, const char *id) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_ClusterFreeSlotRanges)(RedisModuleCtx *ctx, RedisModuleSlotRangeArray *slots) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ExportSharedAPI)(RedisModuleCtx *ctx, const char *apiname, void *func) REDISMODULE_ATTR;
 REDISMODULE_API void * (*RedisModule_GetSharedAPI)(RedisModuleCtx *ctx, const char *apiname) REDISMODULE_ATTR;
@@ -1757,7 +1757,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(ClusterCanAccessKeysInSlot);
     REDISMODULE_GET_API(ClusterPropagateForSlotMigration);
     REDISMODULE_GET_API(ClusterGetLocalSlotRanges);
-    REDISMODULE_GET_API(ClusterGetNodeSlotRanges);
+    REDISMODULE_GET_API(GetClusterNodeSlotRanges);
     REDISMODULE_GET_API(ClusterFreeSlotRanges);
     REDISMODULE_GET_API(ExportSharedAPI);
     REDISMODULE_GET_API(GetSharedAPI);


### PR DESCRIPTION
This initial commit splits the command into two cases: long and short (which currently does nothing).
It also refactors the long form to help writing a clean version for the upcoming short form.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes cluster topology discovery and inter-shard CLUSTERSET propagation; short form depends on new RedisModule cluster slot APIs and misconfiguration could break cross-shard messaging.
> 
> **Overview**
> Adds a **compact `CLUSTERSET` form** (`CLUSTERSET` or `CLUSTERSET AUTH {pwd}`) alongside the existing verbose topology command, and refactors how cluster state is built from incoming arguments.
> 
> **Short form** no longer requires the full `HASHFUNC` / `RANGES` / `SHARD` payload: the module discovers masters, addresses, flags, and slot ranges from the Redis server via `GetClusterNodesList`, `GetClusterNodeInfo`, and the newly wired **`GetClusterNodeSlotRanges`** API (declared in `redismodule.h`). Optional `AUTH` applies one password to all shard connections.
> 
> **Long form** behavior is preserved but split into helpers (`InitClusterData`, `ParseShardEntry`, `SetClusterDataLongForm`). Shared init copies argv for later `CLUSTERSETFROMSHARD` propagation; **only long form** still substitutes the per-target `MYID` token when pushing topology on reconnect/hello retries.
> 
> Command entry points accept either form via `IsLongFormClusterSet` / `IsShortFormClusterSet` instead of a fixed minimum argc of 10.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4de0d20839352b6c78aee6cbab0f785589900c20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->