### PR TITLE
MOD-15749 Replace short-form CLUSTERSET assert with soft NULL check

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1092,8 +1092,20 @@ static int ParseShardEntry(RedisModuleString** argv, int argc, int index,
 static void SetClusterDataShortForm(RedisModuleString** argv, int argc){
     RedisModule_Log(mr_staticCtx, "notice", "Got cluster set command (short form)");
 
-    // Verify we have the help we need from the server
-    RedisModule_Assert(RedisModule_GetClusterNodeSlotRanges != NULL);
+    // Short-form CLUSTERSET requires RedisModule_GetClusterNodeSlotRanges, which
+    // was added to redis core in https://github.com/redis/redis/pull/14953
+    // (planned for OSS 8.10, backported to Enterprise 8.4). If the host redis
+    // does not export this API the function pointer stays NULL after module
+    // load; bail out with a warning rather than crashing the shard. The cluster
+    // remains unconfigured until a long-form CLUSTERSET or a REFRESHCLUSTER
+    // arrives, which matches OSS-mode expectations.
+    if (RedisModule_GetClusterNodeSlotRanges == NULL) {
+        RedisModule_Log(mr_staticCtx, "warning",
+            "Short-form CLUSTERSET received, but RedisModule_GetClusterNodeSlotRanges "
+            "is not available in this Redis build. Use long-form CLUSTERSET or "
+            "REFRESHCLUSTER to configure the cluster.");
+        return;
+    }
 
     clusterCtx.CurrCluster = MR_CALLOC(1, sizeof(*clusterCtx.CurrCluster));
     InitClusterData(clusterCtx.CurrCluster, argv, argc);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1092,13 +1092,10 @@ static int ParseShardEntry(RedisModuleString** argv, int argc, int index,
 static void SetClusterDataShortForm(RedisModuleString** argv, int argc){
     RedisModule_Log(mr_staticCtx, "notice", "Got cluster set command (short form)");
 
-    // Short-form CLUSTERSET requires RedisModule_GetClusterNodeSlotRanges, which
-    // was added to redis core in https://github.com/redis/redis/pull/14953
-    // (planned for OSS 8.10, backported to Enterprise 8.4). If the host redis
-    // does not export this API the function pointer stays NULL after module
-    // load; bail out with a warning rather than crashing the shard. The cluster
-    // remains unconfigured until a long-form CLUSTERSET or a REFRESHCLUSTER
-    // arrives, which matches OSS-mode expectations.
+    // RedisModule_GetClusterNodeSlotRanges may be NULL when the host Redis
+    // build does not export it (e.g. OSS Redis without the backport). Skip
+    // the path with a warning instead of crashing; the cluster stays
+    // unconfigured until a long-form CLUSTERSET or REFRESHCLUSTER arrives.
     if (RedisModule_GetClusterNodeSlotRanges == NULL) {
         RedisModule_Log(mr_staticCtx, "warning",
             "Short-form CLUSTERSET received, but RedisModule_GetClusterNodeSlotRanges "


### PR DESCRIPTION
## Summary

Follow-up to #92. Replace the hard `RedisModule_Assert` at `SetClusterDataShortForm`'s entry with a logged warning + early return, so a module loaded against a redis build that doesn't export `RedisModule_GetClusterNodeSlotRanges` survives a short-form `CLUSTERSET` instead of aborting the shard.

## Why

`#92` added the short-form path which relies on `RedisModule_GetClusterNodeSlotRanges` (added to redis/redis in [#14953](https://github.com/redis/redis/pull/14953), merged 2026-05-25 to `unstable`, planned for OSS 8.10 and Enterprise 8.4 backport).

`REDISMODULE_GET_API(GetClusterNodeSlotRanges)` at module init silently leaves the function pointer NULL if the host redis doesn't expose the API — `RedisModule_GetApi`'s return value is unchecked, and the module continues to load. The next short-form `CLUSTERSET` then trips `RedisModule_Assert(RedisModule_GetClusterNodeSlotRanges != NULL)` and **crashes the shard**.

In Enterprise this is supposed to be prevented by the DMC dispatching by module version ([RED-197643](https://redislabs.atlassian.net/browse/RED-197643)) so short-form is only sent to modules loaded against a redis that has the API. But:

1. **OSS has no DMC.** Anyone (operator, custom tooling, test framework) that sends short-form `CLUSTERSET` to a module on OSS Redis 8.4 without the API takes the shard down.
2. **Version-skew safety.** If RED-197643 has a bug, a misconfiguration, or a module-reload race, the assert is the difference between "wrong topology" and "process aborted".
3. **Mirrors the RediSearch approach.** RediSearch's [`RedisEnterprise_ParseTopology`](https://github.com/RediSearch/RediSearch/blob/master/src/coord/rmr/redise.c#L114) gates on both `argc == 3` *and* the function pointer being non-NULL, then falls through to long-form parsing — same defensive pattern (RediSearch#9779).

## Behavior matrix

| Host redis | CLUSTERSET form | Before this PR | After this PR |
| --- | --- | --- | --- |
| has API | long | works | works (unchanged) |
| has API | short | works | works (unchanged) |
| no API  | long | works | works (unchanged) |
| no API  | short | process crash | warning logged, cluster stays unconfigured, shard alive |

Recovery from the new "no API + short form" outcome is the same path OSS already uses: send `REFRESHCLUSTER`, or a long-form `CLUSTERSET` from a topology-aware caller.

## Test plan

LibMR CI doesn't currently have infrastructure to mock-load the module against a redis build without the new API (the broader testability gap tracked by [MOD-15862](https://redislabs.atlassian.net/browse/MOD-15862)), so this change is exercised via:

- [ ] Code review against the equivalent defensive path in RediSearch [`redise.c:114`](https://github.com/RediSearch/RediSearch/blob/master/src/coord/rmr/redise.c#L114).
- [x] The happy path (redis *with* the API + short-form CLUSTERSET) is implicitly covered by the new `test_short_form_clusterset` in [RedisTimeSeries#2034](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2034), which runs LibMR pinned to a post-#92 master against redis built from `unstable` (which has the API).

A LibMR-side unit test for the no-API case would require the redismock-style mock cluster API plumbing RediSearch added in [#9779](https://github.com/RediSearch/RediSearch/pull/9779) — out of scope here.

## Risk

Very low. One assert -> one NULL-check + log + early return. No behavior change on hosts with the API. No public API change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single defensive guard in cluster setup; no change when the Redis module API is present; only affects the unsupported short-form path.
> 
> **Overview**
> **Short-form `CLUSTERSET` no longer aborts the shard** when the host Redis build does not export `RedisModule_GetClusterNodeSlotRanges` (optional API resolved at module load via `RedisModule_GetApi`).
> 
> In `SetClusterDataShortForm`, the entry **`RedisModule_Assert(RedisModule_GetClusterNodeSlotRanges != NULL)`** is replaced with a **NULL check**, a **warning** log that points operators to long-form `CLUSTERSET` or `REFRESHCLUSTER`, and an **early return**. Cluster topology is left **unchanged / unconfigured** instead of crashing; behavior on Redis builds that **do** provide the API is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6a223ca7bb347214c13de8c28b675d791a05e8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->