### PR TITLE
MOD-15896 Detect oss cluster at MR_ClusterInit

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1659,10 +1659,12 @@ int MR_ClusterInit(RedisModuleCtx* rctx, char *password) {
     if (ceReply && RedisModule_CallReplyType(ceReply) == REDISMODULE_REPLY_ARRAY &&
         RedisModule_CallReplyLength(ceReply) >= 2) {
         RedisModuleCallReply *val = RedisModule_CallReplyArrayElement(ceReply, 1);
-        size_t vlen = 0;
-        const char *vstr = RedisModule_CallReplyStringPtr(val, &vlen);
-        if (vstr && vlen == 3 && strncmp(vstr, "yes", 3) == 0) {
-            ossClusterRuntime = true;
+        if (RedisModule_CallReplyType(val) == REDISMODULE_REPLY_STRING) {
+            size_t vlen = 0;
+            const char *vstr = RedisModule_CallReplyStringPtr(val, &vlen);
+            if (vstr && vlen == 3 && strncmp(vstr, "yes", 3) == 0) {
+                ossClusterRuntime = true;
+            }
         }
     }
     if (ceReply) {
@@ -1673,7 +1675,9 @@ int MR_ClusterInit(RedisModuleCtx* rctx, char *password) {
     }
     RedisModule_FreeServerInfo(rctx, info);
 
-    RedisModule_Log(rctx, "notice", "Detected redis %s", clusterCtx.isOss? "oss" : "enterprise");
+    RedisModule_Log(rctx, "notice", "Detected redis %s (cluster-enabled=%s)",
+                    clusterCtx.isOss ? "oss" : "enterprise",
+                    ossClusterRuntime ? "yes" : "no");
 
     const char *command_flags = "readonly deny-script";
     if (!clusterCtx.isOss) {

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1649,31 +1649,48 @@ int MR_ClusterInit(RedisModuleCtx* rctx, char *password) {
     clusterCtx.password = password ? MR_STRDUP(password) : NULL;
     memset(clusterCtx.myId, '0', REDISMODULE_NODE_ID_LEN);
 
-    RedisModuleServerInfoData *info = RedisModule_GetServerInfo(rctx, "Server");
-    const char *rlecVersion = RedisModule_ServerInfoGetFieldC(info, "rlec_version");
     /* Note: RedisModule_GetContextFlags() does NOT report
      * REDISMODULE_CTX_FLAGS_CLUSTER yet at module-load time, so read the
      * cluster-enabled config directly to learn the runtime mode. */
     bool ossClusterRuntime = false;
     RedisModuleCallReply *ceReply = RedisModule_Call(rctx, "config", "cc", "get", "cluster-enabled");
-    if (ceReply && RedisModule_CallReplyType(ceReply) == REDISMODULE_REPLY_ARRAY &&
-        RedisModule_CallReplyLength(ceReply) >= 2) {
-        RedisModuleCallReply *val = RedisModule_CallReplyArrayElement(ceReply, 1);
-        if (RedisModule_CallReplyType(val) == REDISMODULE_REPLY_STRING) {
+    if (ceReply) {
+        /* CONFIG GET replies as a flat array in RESP2 and as a map in RESP3.
+         * The module ctx defaults to RESP2, but handle both shapes so a future
+         * RESP3 default can't silently break detection and misclassify an
+         * OSS-cluster shard as enterprise. */
+        int ceType = RedisModule_CallReplyType(ceReply);
+        RedisModuleCallReply *val = NULL;
+        if (ceType == REDISMODULE_REPLY_ARRAY && RedisModule_CallReplyLength(ceReply) >= 2) {
+            val = RedisModule_CallReplyArrayElement(ceReply, 1);
+        } else if (ceType == REDISMODULE_REPLY_MAP && RedisModule_CallReplyMapElement &&
+                   RedisModule_CallReplyLength(ceReply) >= 1) {
+            RedisModule_CallReplyMapElement(ceReply, 0, NULL, &val);
+        }
+        if (val && RedisModule_CallReplyType(val) == REDISMODULE_REPLY_STRING) {
             size_t vlen = 0;
             const char *vstr = RedisModule_CallReplyStringPtr(val, &vlen);
-            if (vstr && vlen == 3 && strncmp(vstr, "yes", 3) == 0) {
+            /* CONFIG GET returns the canonical lowercase "yes"/"no" (Redis
+             * spec), so a case-sensitive compare of exactly 3 bytes is safe. */
+            if (vstr && vlen == 3 && memcmp(vstr, "yes", 3) == 0) {
                 ossClusterRuntime = true;
             }
         }
-    }
-    if (ceReply) {
         RedisModule_FreeCallReply(ceReply);
     }
-    if (rlecVersion && !ossClusterRuntime) {
+    /* rlec_version is only present on enterprise binaries. It was already
+     * parsed into MR_RlecMajorVersion by MR_GetRedisVersion() (run before
+     * MR_ClusterInit), so reuse it here instead of fetching Server info a
+     * second time; MR_RlecMajorVersion >= 0 means the field was present.
+     *
+     * Treat the shard as enterprise only when rlec_version is present AND we
+     * are not in OSS cluster mode. This is the load-bearing decision of the
+     * PR: it unblocks an enterprise binary running as an OSS cluster (e.g. the
+     * env0 testing setup), which must take the OSS path (internal-secret AUTH,
+     * no _proxy-filtered command flags) rather than the enterprise path. */
+    if (MR_RlecMajorVersion >= 0 && !ossClusterRuntime) {
         clusterCtx.isOss = false;
     }
-    RedisModule_FreeServerInfo(rctx, info);
 
     RedisModule_Log(rctx, "notice", "Detected redis %s (cluster-enabled=%s)",
                     clusterCtx.isOss ? "oss" : "enterprise",

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1653,6 +1653,7 @@ int MR_ClusterInit(RedisModuleCtx* rctx, char *password) {
      * REDISMODULE_CTX_FLAGS_CLUSTER yet at module-load time, so read the
      * cluster-enabled config directly to learn the runtime mode. */
     bool ossClusterRuntime = false;
+    bool ceResolved = false;
     RedisModuleCallReply *ceReply = RedisModule_Call(rctx, "config", "cc", "get", "cluster-enabled");
     if (ceReply) {
         /* CONFIG GET replies as a flat array in RESP2 and as a map in RESP3.
@@ -1670,25 +1671,40 @@ int MR_ClusterInit(RedisModuleCtx* rctx, char *password) {
         if (val && RedisModule_CallReplyType(val) == REDISMODULE_REPLY_STRING) {
             size_t vlen = 0;
             const char *vstr = RedisModule_CallReplyStringPtr(val, &vlen);
-            /* CONFIG GET returns the canonical lowercase "yes"/"no" (Redis
-             * spec), so a case-sensitive compare of exactly 3 bytes is safe. */
-            if (vstr && vlen == 3 && memcmp(vstr, "yes", 3) == 0) {
-                ossClusterRuntime = true;
+            if (vstr) {
+                ceResolved = true;
+                /* CONFIG GET returns the canonical lowercase "yes"/"no" (Redis
+                 * spec), so a case-sensitive compare of exactly 3 bytes is safe. */
+                if (vlen == 3 && memcmp(vstr, "yes", 3) == 0) {
+                    ossClusterRuntime = true;
+                }
             }
         }
         RedisModule_FreeCallReply(ceReply);
     }
-    /* rlec_version is only present on enterprise binaries. It was already
-     * parsed into MR_RlecMajorVersion by MR_GetRedisVersion() (run before
-     * MR_ClusterInit), so reuse it here instead of fetching Server info a
-     * second time; MR_RlecMajorVersion >= 0 means the field was present.
+    if (!ceResolved) {
+        /* CONFIG GET cluster-enabled should always succeed; an error, an
+         * unexpected reply shape, or an empty value leaves the runtime cluster
+         * mode unknown. Keep the conservative default (ossClusterRuntime stays
+         * false, i.e. an rlec_version shard is treated as enterprise as before)
+         * but log it so a resulting misclassification is diagnosable rather than
+         * silent. */
+        RedisModule_Log(rctx, "warning",
+                        "Could not read cluster-enabled config; assuming not in OSS cluster mode");
+    }
+    /* rlec_version is only present on enterprise binaries. Its presence was
+     * already detected by MR_GetRedisVersion() (run before MR_ClusterInit) and
+     * recorded in MR_RlecVersionPresent, so reuse it here instead of fetching
+     * Server info a second time. Use the presence flag, not MR_RlecMajorVersion
+     * >= 0: the latter only becomes true once sscanf parses the version, so a
+     * present-but-unparseable rlec_version would otherwise read as OSS.
      *
      * Treat the shard as enterprise only when rlec_version is present AND we
      * are not in OSS cluster mode. This is the load-bearing decision of the
      * PR: it unblocks an enterprise binary running as an OSS cluster (e.g. the
      * env0 testing setup), which must take the OSS path (internal-secret AUTH,
      * no _proxy-filtered command flags) rather than the enterprise path. */
-    if (MR_RlecMajorVersion >= 0 && !ossClusterRuntime) {
+    if (MR_RlecVersionPresent && !ossClusterRuntime) {
         clusterCtx.isOss = false;
     }
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -415,7 +415,7 @@ static void SendAuthCommandIfNeeded(const struct redisAsyncContext* c, const Nod
         redisAsyncCommand((redisAsyncContext*)c, NULL, NULL, "AUTH %s", n->password);
         return;
     }
-    if (RedisModule_GetInternalSecret && !MR_IsEnterpriseBuild()) {
+    if (RedisModule_GetInternalSecret && clusterCtx.isOss) {
         /* OSS deployment that support internal secret, lets use it. */
         RedisModule_ThreadSafeContextLock(mr_staticCtx);
         size_t len;
@@ -449,7 +449,7 @@ static void MR_HelloResponseArrived(struct redisAsyncContext* c, void* a, void* 
             // accepted connections but did not set its internal secret to the cluster's yet.
             // In such cases we will have a regular (i.e., non-internal) connection and the
             // hidden commands (including `<module>.HELLO`) will not be visible to us.
-            if (!MR_IsEnterpriseBuild() && strstr(reply->str, "unknown command") != NULL)
+            if (clusterCtx.isOss && strstr(reply->str, "unknown command") != NULL)
                 SendAuthCommandIfNeeded(c, n);
         }
         n->resendHelloEvent = MR_EventLoopAddTaskWithDelay(MR_ClusterResendHelloMessage, n, RETRY_INTERVAL);
@@ -1651,7 +1651,24 @@ int MR_ClusterInit(RedisModuleCtx* rctx, char *password) {
 
     RedisModuleServerInfoData *info = RedisModule_GetServerInfo(rctx, "Server");
     const char *rlecVersion = RedisModule_ServerInfoGetFieldC(info, "rlec_version");
-    if (rlecVersion) {
+    /* Note: RedisModule_GetContextFlags() does NOT report
+     * REDISMODULE_CTX_FLAGS_CLUSTER yet at module-load time, so read the
+     * cluster-enabled config directly to learn the runtime mode. */
+    bool ossClusterRuntime = false;
+    RedisModuleCallReply *ceReply = RedisModule_Call(rctx, "config", "cc", "get", "cluster-enabled");
+    if (ceReply && RedisModule_CallReplyType(ceReply) == REDISMODULE_REPLY_ARRAY &&
+        RedisModule_CallReplyLength(ceReply) >= 2) {
+        RedisModuleCallReply *val = RedisModule_CallReplyArrayElement(ceReply, 1);
+        size_t vlen = 0;
+        const char *vstr = RedisModule_CallReplyStringPtr(val, &vlen);
+        if (vstr && vlen == 3 && strncmp(vstr, "yes", 3) == 0) {
+            ossClusterRuntime = true;
+        }
+    }
+    if (ceReply) {
+        RedisModule_FreeCallReply(ceReply);
+    }
+    if (rlecVersion && !ossClusterRuntime) {
         clusterCtx.isOss = false;
     }
     RedisModule_FreeServerInfo(rctx, info);
@@ -1659,7 +1676,7 @@ int MR_ClusterInit(RedisModuleCtx* rctx, char *password) {
     RedisModule_Log(rctx, "notice", "Detected redis %s", clusterCtx.isOss? "oss" : "enterprise");
 
     const char *command_flags = "readonly deny-script";
-    if (MR_IsEnterpriseBuild()) {
+    if (!clusterCtx.isOss) {
         command_flags = "readonly deny-script _proxy-filtered";
     } else {
         if (RedisModule_GetInternalSecret) {
@@ -1668,7 +1685,7 @@ int MR_ClusterInit(RedisModuleCtx* rctx, char *password) {
         }
     }
 
-    if (!MR_IsEnterpriseBuild()) {
+    if (clusterCtx.isOss) {
         /* Refresh cluster is only relevant for oss, also notice that refresh cluster
          * is not considered internal and should be performed by the user. */
         if (!RegisterRedisCommand(rctx, CLUSTER_REFRESH_COMMAND, MR_ClusterRefresh,
@@ -1680,7 +1697,7 @@ int MR_ClusterInit(RedisModuleCtx* rctx, char *password) {
     /* The CLUSTERSET should be visible in COMMAND LIST, otherwise the RAMP packer
      * will miss it and a module will not be notified in an enterprise cluster */
     if (!RegisterRedisCommand(rctx, CLUSTER_SET_COMMAND, MR_ClusterSet,
-                            MR_IsEnterpriseBuild() ? "readonly deny-script _proxy-filtered" : "readonly deny-script",
+                            !clusterCtx.isOss ? "readonly deny-script _proxy-filtered" : "readonly deny-script",
                             0, 0, -1)) {
         return REDISMODULE_ERR;
     }

--- a/src/common.h
+++ b/src/common.h
@@ -30,5 +30,6 @@ extern int MR_RlecMajorVersion;
 extern int MR_RlecMinorVersion;
 extern int MR_RlecPatchVersion;
 extern int MR_RlecBuild;
+extern int MR_RlecVersionPresent;
 
 #endif /* SRC_COMMON_H_ */

--- a/src/common.h
+++ b/src/common.h
@@ -30,10 +30,5 @@ extern int MR_RlecMajorVersion;
 extern int MR_RlecMinorVersion;
 extern int MR_RlecPatchVersion;
 extern int MR_RlecBuild;
-extern int MR_IsEnterprise;
-
-static inline int MR_IsEnterpriseBuild() {
-    return MR_IsEnterprise;
-}
 
 #endif /* SRC_COMMON_H_ */

--- a/src/mr.c
+++ b/src/mr.c
@@ -35,6 +35,7 @@ int MR_RlecMajorVersion;
 int MR_RlecMinorVersion;
 int MR_RlecPatchVersion;
 int MR_RlecBuild;
+int MR_RlecVersionPresent;
 
 RedisModuleCtx* mr_staticCtx;
 
@@ -1545,6 +1546,10 @@ static void MR_GetRedisVersion() {
     MR_RlecPatchVersion = -1;
     MR_RlecBuild = -1;
     const char *enterpriseStr = strstr(replyStr, "rlec_version:");
+    /* Presence of the rlec_version field is the enterprise signal, independent
+     * of whether the version numbers below parse. Record it separately so a
+     * present-but-unparseable value isn't mistaken for an OSS build. */
+    MR_RlecVersionPresent = (enterpriseStr != NULL);
     if (enterpriseStr) {
         n = sscanf(enterpriseStr,
                    "rlec_version:%d.%d.%d-%d",

--- a/src/mr.c
+++ b/src/mr.c
@@ -35,7 +35,6 @@ int MR_RlecMajorVersion;
 int MR_RlecMinorVersion;
 int MR_RlecPatchVersion;
 int MR_RlecBuild;
-int MR_IsEnterprise;
 
 RedisModuleCtx* mr_staticCtx;
 
@@ -1545,10 +1544,8 @@ static void MR_GetRedisVersion() {
     MR_RlecMinorVersion = -1;
     MR_RlecPatchVersion = -1;
     MR_RlecBuild = -1;
-    MR_IsEnterprise = 0;
     const char *enterpriseStr = strstr(replyStr, "rlec_version:");
     if (enterpriseStr) {
-        MR_IsEnterprise = 1;
         n = sscanf(enterpriseStr,
                    "rlec_version:%d.%d.%d-%d",
                    &MR_RlecMajorVersion,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes load-time cluster classification and inter-shard AUTH/command ACLs; misreading `cluster-enabled` is logged and defaults conservatively, but wrong classification would break shard connectivity or enterprise proxy behavior.
> 
> **Overview**
> **Cluster behavior no longer keys off “enterprise build” alone.** At `MR_ClusterInit`, the module reads `CONFIG GET cluster-enabled` (handling RESP2 array and RESP3 map replies) and combines that with **`MR_RlecVersionPresent`** (whether `rlec_version` appeared in server INFO) to set **`clusterCtx.isOss`**. A shard is treated as enterprise only when `rlec_version` is present **and** cluster mode is not OSS—so an enterprise binary running as an OSS cluster (e.g. env0 tests) uses the OSS path: internal-secret AUTH, `internal` command flags, and no `_proxy-filtered`.
> 
> **`MR_IsEnterpriseBuild()` / `MR_IsEnterprise` are removed.** Version parsing in `MR_GetRedisVersion` now sets **`MR_RlecVersionPresent`** independently of whether version numbers parse, avoiding misclassifying unparseable enterprise strings as OSS. Hello/auth retry logic and command registration use **`clusterCtx.isOss`** instead of the old enterprise-build helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ebd3cf39b32e980928a3865b81385ba3e3c5246. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->