### PR TITLE
MOD-16549 Return an error from short-form CLUSTERSET when the slot-ranges API is missing

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -172,6 +172,7 @@ typedef struct ClusterSetCtx {
     RedisModuleString **argv;
     int argc;
     bool force;
+    const char* errReply;  // NULL => reply "OK"; otherwise reply this error to the client
 }ClusterSetCtx;
 
 typedef enum MessageReply {
@@ -1089,19 +1090,21 @@ static int ParseShardEntry(RedisModuleString** argv, int argc, int index,
     return index;
 }
 
-static void SetClusterDataShortForm(RedisModuleString** argv, int argc){
+static int SetClusterDataShortForm(RedisModuleString** argv, int argc){
     RedisModule_Log(mr_staticCtx, "notice", "Got cluster set command (short form)");
 
     // RedisModule_GetClusterNodeSlotRanges may be NULL when the host Redis
-    // build does not export it (e.g. OSS Redis without the backport). Skip
-    // the path with a warning instead of crashing; the cluster stays
-    // unconfigured until a long-form CLUSTERSET or REFRESHCLUSTER arrives.
+    // build does not export it (e.g. OSS Redis without the backport). Reject
+    // the command with an error instead of crashing or silently no-op'ing, so
+    // the caller (e.g. DMC) can fall back to the long-form CLUSTERSET. The
+    // cluster stays unconfigured until a long-form CLUSTERSET or REFRESHCLUSTER
+    // arrives.
     if (RedisModule_GetClusterNodeSlotRanges == NULL) {
         RedisModule_Log(mr_staticCtx, "warning",
             "Short-form CLUSTERSET received, but RedisModule_GetClusterNodeSlotRanges "
             "is not available in this Redis build. Use long-form CLUSTERSET or "
             "REFRESHCLUSTER to configure the cluster.");
-        return;
+        return REDISMODULE_ERR;
     }
 
     clusterCtx.CurrCluster = MR_CALLOC(1, sizeof(*clusterCtx.CurrCluster));
@@ -1127,7 +1130,7 @@ static void SetClusterDataShortForm(RedisModuleString** argv, int argc){
     char **nodeList = RedisModule_GetClusterNodesList(mr_staticCtx, &numNodes);
     if (!nodeList) {
         RedisModule_Log(mr_staticCtx, "warning", "Failed to get cluster nodes list");
-        return;
+        return REDISMODULE_ERR;
     }
 
     for (size_t i = 0; i < numNodes; i++) {
@@ -1181,6 +1184,7 @@ static void SetClusterDataShortForm(RedisModuleString** argv, int argc){
 
     clusterCtx.clusterSize = mr_dictSize(clusterCtx.CurrCluster->nodes);
     mr_dictEmpty(clusterCtx.nodesMsgIds, NULL);
+    return REDISMODULE_OK;
 }
 
 static void SetClusterDataLongForm(RedisModuleString** argv, int argc){
@@ -1248,16 +1252,19 @@ static void SetClusterDataLongForm(RedisModuleString** argv, int argc){
     mr_dictEmpty(clusterCtx.nodesMsgIds, NULL);
 }
 
-static void MR_SetClusterData(RedisModuleString** argv, int argc){
+static int MR_SetClusterData(RedisModuleString** argv, int argc){
     if(clusterCtx.CurrCluster)
         MR_ClusterFree();
 
-    if (IsLongFormClusterSet(argc))
+    if (IsLongFormClusterSet(argc)) {
         SetClusterDataLongForm(argv, argc);
-    else if (IsShortFormClusterSet(argc))
-        SetClusterDataShortForm(argv, argc);
-    else
+        return REDISMODULE_OK;
+    } else if (IsShortFormClusterSet(argc)) {
+        return SetClusterDataShortForm(argv, argc);
+    } else {
         RedisModule_Log(mr_staticCtx, "warning", "Could not parse cluster set arguments");
+        return REDISMODULE_ERR;
+    }
 }
 
 /* runs in the event loop so its safe to update cluster
@@ -1276,19 +1283,26 @@ static void MR_ClusterRefreshFromCommand(void* ctx){
 static void MR_ClusterSetFromCommand(void* ctx){
     ClusterSetCtx* csCtx = ctx;
     if (!clusterCtx.CurrCluster || csCtx->force) {
-        MR_SetClusterData(csCtx->argv, csCtx->argc);
+        if (MR_SetClusterData(csCtx->argv, csCtx->argc) != REDISMODULE_OK) {
+            csCtx->errReply = CLUSTER_ERROR" Failed to set cluster topology";
+        }
     }
     RedisModule_UnblockClient(csCtx->bc, csCtx);
 }
 
 static int MR_ClusterSetUnblock(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     ClusterSetCtx* csCtx = RedisModule_GetBlockedClientPrivateData(ctx);
+    const char* errReply = csCtx->errReply;
     for(size_t i = 0 ; i < csCtx->argc ; ++i){
         RedisModule_FreeString(NULL, csCtx->argv[i]);
     }
     MR_FREE(csCtx->argv);
     MR_FREE(csCtx);
-    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    if (errReply) {
+        RedisModule_ReplyWithError(ctx, errReply);
+    } else {
+        RedisModule_ReplyWithSimpleString(ctx, "OK");
+    }
     return REDISMODULE_OK;
 }
 
@@ -1298,6 +1312,7 @@ static int MR_ClusterSetInternal(RedisModuleCtx *ctx, RedisModuleString **argv, 
     csCtx->argv = argv;
     csCtx->argc = argc;
     csCtx->force = force;
+    csCtx->errReply = NULL;
     MR_EventLoopAddTask(MR_ClusterSetFromCommand, csCtx);
     return REDISMODULE_OK;
 }

--- a/tests/mr_test_module/pytests/test_errors.py
+++ b/tests/mr_test_module/pytests/test_errors.py
@@ -1,4 +1,6 @@
-from common import MRTestDecorator
+import unittest
+
+from common import MRTestDecorator, is_redis_version_is_lower_than, promote_internal_client_if_supported
 
 @MRTestDecorator()
 def testMRMapError(env, conn):
@@ -32,3 +34,18 @@ def testInternalCommandFromScript(env, conn):
     env.expect('eval', "return redis.call('MRTESTS.CLUSTERSETFROMSHARD')", '0').error().contains('command is not allowed from script')
     env.expect('eval', "return redis.call('MRTESTS.INFOCLUSTER')", '0').error().contains('command is not allowed from script')
     env.expect('eval', "return redis.call('MRTESTS.FORCESHARDSCONNECTION')", '0').error().contains('command is not allowed from script')
+
+@MRTestDecorator(skipClusterInitialisation=True)
+def testShortFormClusterSetWithoutSlotRangesApi(env, conn):
+    # The short form of CLUSTERSET relies on RedisModule_GetClusterNodeSlotRanges
+    # (redis/redis#14953). On Redis builds that don't export it, the command must
+    # reply with an error -- so callers (e.g. DMC) can fall back to the long form --
+    # instead of silently replying OK while leaving the cluster unconfigured.
+    if not is_redis_version_is_lower_than('8.0.0'):
+        # Newer builds may export the API, in which case the short form is accepted.
+        # That path is covered end-to-end by RedisTimeSeries' flow tests.
+        raise unittest.SkipTest()
+    promote_internal_client_if_supported(env=env)
+    env.expect('MRTESTS.CLUSTERSET').error().contains('Failed to set cluster topology')
+    # Wrong arity is rejected up front, regardless of the API's availability.
+    env.expect('MRTESTS.CLUSTERSET', 'AUTH').error().contains('Could not parse cluster set arguments')


### PR DESCRIPTION
## Problem

The short form of `CLUSTERSET` relies on `RedisModule_GetClusterNodeSlotRanges` ([redis/redis#14953](https://github.com/redis/redis/pull/14953)). When the host Redis build does not export it, [#94](https://github.com/RedisGears/LibMR/pull/94) made `SetClusterDataShortForm` log a warning and return early to avoid a crash — **but the command still replied `+OK`** while leaving the cluster unconfigured.

This breaks the planned DMC rollout strategy: DMC wants to send the short form and **fall back to the long form on error**. With a silent `+OK`, DMC can't tell "configured" from "module silently no-op'd on an old core," so it never falls back and the cluster stays unconfigured.

For comparison, RediSearch already returns an error in this case (its short-form guard is `argc == 3 && RedisModule_GetClusterNodeSlotRanges`, which short-circuits to the long-form parser → `ERROR_MISSING("MYID")` → error reply).

## Fix

Propagate a status out of `SetClusterDataShortForm` → `MR_SetClusterData` → `ClusterSetCtx`, and have `MR_ClusterSetUnblock` reply with an error (`-ERRCLUSTER Failed to set cluster topology`) instead of `+OK` when configuration failed. Follows the existing `MessageCtx.reply` deferred-reply idiom used by the inner-communication path.

Covers both failure paths in the short form: the missing-API case and the `RedisModule_GetClusterNodesList` failure. The success path (API present) is unchanged — still replies `+OK`. Applies to both `TIMESERIES.CLUSTERSET` and `…CLUSTERSETFROMSHARD`, which share `MR_ClusterSetInternal`.

## Test

Adds `testShortFormClusterSetWithoutSlotRangesApi` to `test_errors.py`, gated to Redis < 8.0 (the `7.2`/`7.4` CI legs, which predate the API), asserting the short form returns an error. The success path is covered end-to-end by RedisTimeSeries' `test_short_form_clusterset` flow test (runs in `oss-cluster` against a build that exports the API).

Built locally (`make libmr`); `cluster.c` compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster bootstrap for CLUSTERSET/CLUSTERSETFROMSHARD; behavior change only on previously failing short-form paths, but mis-detection could affect rollout automation.
> 
> **Overview**
> **Short-form `CLUSTERSET` no longer replies `OK` when topology cannot be applied.** `SetClusterDataShortForm` and `MR_SetClusterData` now return `REDISMODULE_OK` / `REDISMODULE_ERR` instead of void, covering a missing `RedisModule_GetClusterNodeSlotRanges` and failure to obtain the cluster nodes list.
> 
> Failures are stored on `ClusterSetCtx.errReply` and surfaced in `MR_ClusterSetUnblock` as `-ERRCLUSTER Failed to set cluster topology`, so callers (e.g. DMC) can retry with long-form `CLUSTERSET`. Successful short-form behavior is unchanged.
> 
> A pytest on Redis &lt; 8.0 asserts the error when the slot-ranges API is absent, plus existing arity validation for malformed short-form args.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3179741e15be243a5ed02b0823b3035d9f076af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->