### PR TITLE
MOD-16382 Add MR_ClusterRefreshTopology for event-driven OSS topology refresh

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -957,7 +957,7 @@ static void MR_RefreshClusterData(){
 
 /* Reconcile the LibMR cluster view with a fresh CLUSTER SLOTS, reusing the existing
  * Node structs (and their live connections) wherever possible. This is the single
- * entry point the debounced topology-change handler calls, regardless of which
+ * entry point the topology-change handler calls, regardless of which
  * reason flags the event carried, and it decides what to do from the actual
  * primary-set delta:
  *
@@ -1432,75 +1432,29 @@ static int MR_ClusterRefresh(RedisModuleCtx *ctx, RedisModuleString **argv, int 
     return REDISMODULE_OK;
 }
 
-/* Trailing debounce for the automatic topology refresh. A reshard issues
- * CLUSTER SETSLOT per slot, so the topology-change event can fire thousands of
- * times in quick succession; a naive refresh-per-event would tear down and
- * rebuild every inter-shard connection thousands of times (MR_RefreshClusterData
- * frees the whole cluster), which is both wasteful and disruptive to in-flight
- * cross-shard queries. Instead every event just bumps a counter; an event-loop
- * task reschedules itself until the counter stops advancing for one debounce
- * window, then does a single refresh. Net effect: one refresh per burst. */
-#define MR_TOPOLOGY_DEBOUNCE_MS 100
-
-static unsigned long long clusterTopoEventSeq = 0; /* bumped by the event callback */
-static char clusterTopoDebounceArmed = 0;          /* at most one debounce chain */
-static unsigned long long clusterTopoSeenSeq = 0;  /* event-loop thread only */
-
-/* Runs on the event loop. Refreshes once the event counter has been stable for
- * a full debounce window, otherwise waits another window. */
-static void MR_TopoDebounceCheck(void* ctx){
+/* Runs on the event loop. MR_UpdateClusterSlots decides from the actual
+ * primary-set delta whether a full rebuild (which aborts in-flight executions)
+ * is needed or a connection-preserving in-place slot-map update suffices, so a
+ * redundant event costs one CLUSTER SLOTS read and never drops in-flight
+ * multi-key commands. */
+static void MR_TopoRefreshTask(void* ctx){
     REDISMODULE_NOT_USED(ctx);
-    unsigned long long cur = __atomic_load_n(&clusterTopoEventSeq, __ATOMIC_SEQ_CST);
-    if (cur != clusterTopoSeenSeq) {
-        /* More events arrived during the window; keep waiting. */
-        clusterTopoSeenSeq = cur;
-        MR_EventLoopAddTaskWithDelay(MR_TopoDebounceCheck, NULL, MR_TOPOLOGY_DEBOUNCE_MS);
-        return;
-    }
-    /* Quiesced. Disarm, then re-check so an event that raced in just now is not
-     * lost (it would otherwise see the armed flag set and not start a chain). */
-    __atomic_clear(&clusterTopoDebounceArmed, __ATOMIC_SEQ_CST);
-    if (__atomic_load_n(&clusterTopoEventSeq, __ATOMIC_SEQ_CST) != cur) {
-        if (!__atomic_test_and_set(&clusterTopoDebounceArmed, __ATOMIC_SEQ_CST)) {
-            clusterTopoSeenSeq = __atomic_load_n(&clusterTopoEventSeq, __ATOMIC_SEQ_CST);
-            MR_EventLoopAddTaskWithDelay(MR_TopoDebounceCheck, NULL, MR_TOPOLOGY_DEBOUNCE_MS);
-        }
-        return;
-    }
-    /* Quiesced for real. Reconcile against CLUSTER SLOTS: MR_UpdateClusterSlots
-     * decides from the actual primary-set delta whether a full rebuild (which aborts
-     * in-flight executions) is needed or a connection-preserving in-place slot-map
-     * update suffices. The event's reason flags therefore don't need to be exact,
-     * and a spurious/over-broad event never drops in-flight multi-key commands. If an
-     * event raced in after the re-check above it re-armed its own chain; a redundant
-     * reconcile is a harmless no-op. */
     MR_UpdateClusterSlots();
 }
 
-/* Runs on the event loop: start a debounce chain (called via the thread-safe
- * MR_EventLoopAddTask so the delayed timer is armed from the loop thread). */
-static void MR_TopoDebounceStart(void* ctx){
-    REDISMODULE_NOT_USED(ctx);
-    clusterTopoSeenSeq = __atomic_load_n(&clusterTopoEventSeq, __ATOMIC_SEQ_CST);
-    MR_EventLoopAddTaskWithDelay(MR_TopoDebounceCheck, NULL, MR_TOPOLOGY_DEBOUNCE_MS);
-}
-
-/* Request an OSS cluster topology refresh, debounced. No-op when not running as
- * an OSS cluster (Enterprise/standalone), mirroring the OSS-only registration of
- * the REFRESHCLUSTER command, so it is safe to call unconditionally from a Redis
+/* Request an OSS cluster topology refresh; every event schedules one reconcile
+ * on the event loop. No-op when not running as an OSS cluster
+ * (Enterprise/standalone), mirroring the OSS-only registration of the
+ * REFRESHCLUSTER command, so it is safe to call unconditionally from a Redis
  * server-event callback. */
 void MR_ClusterRefreshTopology(int change_flags){
     if (!clusterCtx.isOss) return;
-    /* change_flags is advisory: the debounced refresh reconciles against CLUSTER
-     * SLOTS and decides rebuild-vs-in-place from the actual primary-set delta, so we
-     * don't act on the reason bits here. Kept in the signature for callers / future
-     * use. */
+    /* change_flags is advisory: the refresh reconciles against CLUSTER SLOTS
+     * and decides rebuild-vs-in-place from the actual primary-set delta, so we
+     * don't act on the reason bits here. Kept in the signature for callers /
+     * future use. */
     REDISMODULE_NOT_USED(change_flags);
-    __atomic_add_fetch(&clusterTopoEventSeq, 1, __ATOMIC_SEQ_CST);
-    if (__atomic_test_and_set(&clusterTopoDebounceArmed, __ATOMIC_SEQ_CST)) {
-        return; /* a debounce chain is already running; it will see the bump */
-    }
-    MR_EventLoopAddTask(MR_TopoDebounceStart, NULL);
+    MR_EventLoopAddTask(MR_TopoRefreshTask, NULL);
 }
 
 static int MR_ClusterSet(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -955,6 +955,91 @@ static void MR_RefreshClusterData(){
     mr_dictEmpty(clusterCtx.nodesMsgIds, NULL);
 }
 
+/* Update only the slot->node routing from a fresh CLUSTER SLOTS, reusing the
+ * existing Node structs (and their live connections) instead of tearing the whole
+ * cluster down and reconnecting. Used for an in-place reshard (only the
+ * REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_SLOT reason set): the set of primaries is unchanged,
+ * so only the slot map moved. A full MR_RefreshClusterData would abort in-flight
+ * cross-shard executions (MR_AbortRunningExecutions) and rebuild every connection
+ * for nothing, which is exactly what disrupts fan-out queries running during a
+ * reshard.
+ *
+ * In OSS mode CurrCluster->slots is the routing source of truth (the SendMsgType_BySlot
+ * path), while fan-out (SendMsgType_All) iterates the nodes dict -- both stay correct
+ * here since the node set is unchanged and only slots[] is repointed. Per-node
+ * slotRanges are only consumed by the Enterprise CLUSTERSET build and the debug
+ * RG.INFOCLUSTER reply, so they are intentionally left untouched.
+ *
+ * If a primary we have never seen appears, the change was not purely slot-level
+ * after all (a node entered the serving set); fall back to a full rebuild so the
+ * new shard is set up and connected through the normal path. */
+static void MR_UpdateClusterSlots(){
+    if (!clusterCtx.CurrCluster) {
+        /* Nothing to update incrementally yet; build from scratch. */
+        MR_RefreshClusterData();
+        return;
+    }
+
+    if(!(RedisModule_GetContextFlags(mr_staticCtx) & REDISMODULE_CTX_FLAGS_CLUSTER)){
+        return;
+    }
+
+    RedisModule_Log(mr_staticCtx, "notice", "Got cluster slot-map update (in-place reshard)");
+
+    RedisModule_ThreadSafeContextLock(mr_staticCtx);
+    RedisModuleCallReply *allSlotsReply = RedisModule_Call(mr_staticCtx, "cluster", "c", "slots");
+    RedisModule_ThreadSafeContextUnlock(mr_staticCtx);
+    RedisModule_Assert(RedisModule_CallReplyType(allSlotsReply) == REDISMODULE_REPLY_ARRAY);
+
+    /* Repoint the whole slot map from the fresh reply; reused nodes keep their
+     * connections. Runs on the event-loop thread, same as the dispatch path that
+     * reads slots[], so no reader can observe a half-updated map. */
+    memset(clusterCtx.CurrCluster->slots, 0, sizeof(clusterCtx.CurrCluster->slots));
+
+    for(size_t i = 0 ; i < RedisModule_CallReplyLength(allSlotsReply) ; ++i){
+        RedisModuleCallReply *slotRangeReply = RedisModule_CallReplyArrayElement(allSlotsReply, i);
+
+        RedisModuleCallReply *minSlotReply = RedisModule_CallReplyArrayElement(slotRangeReply, 0);
+        RedisModule_Assert(RedisModule_CallReplyType(minSlotReply) == REDISMODULE_REPLY_INTEGER);
+        long long minSlot = RedisModule_CallReplyInteger(minSlotReply);
+
+        RedisModuleCallReply *maxSlotReply = RedisModule_CallReplyArrayElement(slotRangeReply, 1);
+        RedisModule_Assert(RedisModule_CallReplyType(maxSlotReply) == REDISMODULE_REPLY_INTEGER);
+        long long maxSlot = RedisModule_CallReplyInteger(maxSlotReply);
+
+        RedisModuleCallReply *nodeDetailsReply = RedisModule_CallReplyArrayElement(slotRangeReply, 2);
+        RedisModule_Assert(RedisModule_CallReplyType(nodeDetailsReply) == REDISMODULE_REPLY_ARRAY);
+        RedisModule_Assert(RedisModule_CallReplyLength(nodeDetailsReply) >= 3);
+        RedisModuleCallReply *nodeidReply = RedisModule_CallReplyArrayElement(nodeDetailsReply, 2);
+        size_t idLen;
+        const char* id = RedisModule_CallReplyStringPtr(nodeidReply,&idLen);
+
+        char nodeId[REDISMODULE_NODE_ID_LEN + 1];
+        memcpy(nodeId, id, REDISMODULE_NODE_ID_LEN);
+        nodeId[REDISMODULE_NODE_ID_LEN] = '\0';
+
+        Node* n = MR_GetNode(nodeId);
+        if(!n){
+            /* A primary we did not know about -> not a pure slot move after all. */
+            RedisModule_Log(mr_staticCtx, "notice",
+                "Slot-map update saw an unknown shard %s; doing a full topology refresh", nodeId);
+            RedisModule_FreeCallReply(allSlotsReply);
+            MR_RefreshClusterData();
+            return;
+        }
+
+        if (n->isMe) {
+            clusterCtx.minSlot = minSlot;
+            clusterCtx.maxSlot = maxSlot;
+        }
+
+        for(int k = minSlot ; k <= maxSlot ; ++k){
+            clusterCtx.CurrCluster->slots[k] = n;
+        }
+    }
+    RedisModule_FreeCallReply(allSlotsReply);
+}
+
 static void GenerateRunId(Cluster* cluster){
     RedisModule_GetRandomHexChars(cluster->runId, RUN_ID_SIZE);
     cluster->runId[RUN_ID_SIZE] = '\0';
@@ -1336,6 +1421,20 @@ static int MR_ClusterRefresh(RedisModuleCtx *ctx, RedisModuleString **argv, int 
 static unsigned long long clusterTopoEventSeq = 0; /* bumped by the event callback */
 static char clusterTopoDebounceArmed = 0;          /* at most one debounce chain */
 static unsigned long long clusterTopoSeenSeq = 0;  /* event-loop thread only */
+/* OR of REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_* reasons accumulated across the
+ * events coalesced into the current debounce window, so we can pick the cheapest
+ * refresh that still covers every change. */
+static unsigned int clusterTopoPendingChanges = 0;
+
+/* Reasons that may change the set of primaries we hold connections to -- a node
+ * joined/left (NODE), a primary/replica role flip (ROLE), or an OK/FAIL transition
+ * that can bring shards in or out of service (STATE) -- and therefore require a
+ * full rebuild (reconnect). A SLOT-only change is an in-place reshard between
+ * primaries we are already connected to, so a connection-preserving slot-map
+ * update suffices and avoids aborting in-flight cross-shard queries. */
+#define MR_TOPO_REBUILD_FLAGS (REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE | \
+                               REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_ROLE | \
+                               REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_STATE)
 
 /* Runs on the event loop. Refreshes once the event counter has been stable for
  * a full debounce window, otherwise waits another window. */
@@ -1358,7 +1457,20 @@ static void MR_TopoDebounceCheck(void* ctx){
         }
         return;
     }
-    MR_RefreshClusterData();
+    /* Quiesced for real. Consume the accumulated reason flags and pick the cheapest
+     * refresh that covers them: a full rebuild if the set of primaries may have
+     * changed (NODE/ROLE/STATE), otherwise a connection-preserving slot-map update
+     * for an in-place reshard (SLOT only). If a rebuild-worthy event raced in after
+     * the re-check above, it re-armed its own chain and re-OR'd its bit; whichever
+     * exchange observes the bit does the full rebuild, and the other chain's refresh
+     * is a harmless idempotent slot-map update -- so a membership/role/state change
+     * is never masked by this fast path. */
+    unsigned int pending = __atomic_exchange_n(&clusterTopoPendingChanges, 0u, __ATOMIC_SEQ_CST);
+    if (pending & MR_TOPO_REBUILD_FLAGS) {
+        MR_RefreshClusterData();
+    } else {
+        MR_UpdateClusterSlots();
+    }
 }
 
 /* Runs on the event loop: start a debounce chain (called via the thread-safe
@@ -1373,8 +1485,12 @@ static void MR_TopoDebounceStart(void* ctx){
  * an OSS cluster (Enterprise/standalone), mirroring the OSS-only registration of
  * the REFRESHCLUSTER command, so it is safe to call unconditionally from a Redis
  * server-event callback. */
-void MR_ClusterRefreshTopology(void){
+void MR_ClusterRefreshTopology(int change_flags){
     if (!clusterCtx.isOss) return;
+    /* Accumulate the reason flags before bumping the sequence, so the debounce task
+     * that eventually fires always sees at least the bits for every event it is
+     * coalescing. */
+    __atomic_or_fetch(&clusterTopoPendingChanges, (unsigned int)change_flags, __ATOMIC_SEQ_CST);
     __atomic_add_fetch(&clusterTopoEventSeq, 1, __ATOMIC_SEQ_CST);
     if (__atomic_test_and_set(&clusterTopoDebounceArmed, __ATOMIC_SEQ_CST)) {
         return; /* a debounce chain is already running; it will see the bump */

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -955,136 +955,134 @@ static void MR_RefreshClusterData(){
     mr_dictEmpty(clusterCtx.nodesMsgIds, NULL);
 }
 
-/* Reconcile the LibMR cluster view with a fresh CLUSTER SLOTS, reusing the existing
- * Node structs (and their live connections) wherever possible. This is the single
- * entry point the topology-change handler calls, regardless of which
- * reason flags the event carried, and it decides what to do from the actual
- * primary-set delta:
- *
- *  - If the set of slot-serving primaries is unchanged (only slot ownership moved
- *    between primaries we are already connected to -- an in-place reshard), we just
- *    repoint CurrCluster->slots in place. Connections and in-flight cross-shard
- *    executions are left untouched, so a reshard never drops multi-key commands.
- *  - If the set of primaries changed (a primary entered or left the serving set --
- *    scale-out, scale-in, failover), we escalate to MR_RefreshClusterData, which
- *    reconnects to the new set and aborts in-flight executions (the client retries).
- *
- * Deciding by the primary-set delta rather than by the event's reason flags means an
- * over-broad or spurious notification (a replica re-pointing, an OK<->FAIL flip, a
- * slotless node joining) that does not change the primary set costs only a cheap
- * in-place repoint -- never a connection rebuild or a dropped in-flight multi-key
- * command.
- *
- * In OSS mode CurrCluster->slots is the routing source of truth (the SendMsgType_BySlot
- * path) and fan-out (SendMsgType_All) iterates the nodes dict; both stay correct here.
- * Per-node slotRanges are only consumed by the Enterprise CLUSTERSET build and the
- * debug RG.INFOCLUSTER reply, so they are intentionally left untouched. */
-static void MR_UpdateClusterSlots(){
+/* One entry of a topology view: a master node and one of its slot ranges
+ * (minSlot > maxSlot when it serves none). A master with several ranges
+ * appears once per range. */
+typedef struct TopologyViewEntry {
+    char id[REDISMODULE_NODE_ID_LEN + 1];
+    char ip[INET6_ADDRSTRLEN];
+    unsigned short port;
+    long long minSlot;
+    long long maxSlot;
+} TopologyViewEntry;
+
+/* Build a topology view of the masters currently visible through the cluster
+ * module API (the same source the short-form CLUSTERSET builds from). Masters
+ * serving no slots are left out unless includeSlotless is set. Returns NULL
+ * when the cluster API is unavailable; the caller owns the returned array. */
+static ARR(TopologyViewEntry) BuildClusterApiView(bool includeSlotless){
+    if (RedisModule_GetClusterNodeSlotRanges == NULL)
+        return NULL;
+
+    size_t numNodes;
+    char **nodeList = RedisModule_GetClusterNodesList(mr_staticCtx, &numNodes);
+    if (!nodeList)
+        return NULL;
+
+    ARR(TopologyViewEntry) view = array_new(TopologyViewEntry, numNodes);
+    for (size_t i = 0; i < numNodes; i++) {
+        TopologyViewEntry e = { .minSlot = 0, .maxSlot = -1 };
+        memcpy(e.id, nodeList[i], REDISMODULE_NODE_ID_LEN);  // nodeList[i] is not null-terminated
+        e.id[REDISMODULE_NODE_ID_LEN] = '\0';
+
+        int port, flags;
+        if (RedisModule_GetClusterNodeInfo(mr_staticCtx, e.id, e.ip, NULL, &port, &flags) != REDISMODULE_OK)
+            continue;
+        if (!(flags & REDISMODULE_NODE_MASTER)) continue;  // Skip replica nodes
+        e.port = (unsigned short)port;
+
+        RedisModuleSlotRangeArray *slots = RedisModule_GetClusterNodeSlotRanges(mr_staticCtx, e.id);
+        RedisModule_Assert(slots != NULL);
+        if (slots->num_ranges == 0) {
+            if (includeSlotless)
+                view = array_append(view, e);
+        } else {
+            for (size_t j = 0; j < slots->num_ranges; j++) {
+                e.minSlot = slots->ranges[j].start;
+                e.maxSlot = slots->ranges[j].end;
+                view = array_append(view, e);
+            }
+        }
+        RedisModule_ClusterFreeSlotRanges(mr_staticCtx, slots);
+    }
+    RedisModule_FreeClusterNodesList(nodeList);
+    return view;
+}
+
+/* Compare the view against the current cluster and, when the master set is
+ * unchanged -- same ids at the same addresses -- repoint the slot map in
+ * place, keeping the nodes and their live connections. Returns false when a
+ * master entered/left the set or changed its address; the caller must then do
+ * a full rebuild. Runs on the event-loop thread, same as the dispatch path
+ * that reads slots[], so no reader can observe a half-updated map. */
+static bool MR_TryApplyTopologyInPlace(const TopologyViewEntry* view, size_t n){
     if (!clusterCtx.CurrCluster) {
-        /* Nothing to reconcile against yet; build from scratch. */
-        MR_RefreshClusterData();
-        return;
+        return false;
     }
 
+    /* Pass 1: validate. Every master in the view must already be known, at the
+     * same address; and none we hold may have left (every view id is in the
+     * nodes dict, so an equal distinct count means equal sets). */
+    mr_dict* seen = mr_dictCreate(&mr_dictTypeHeapStrings, NULL);
+    for (size_t i = 0 ; i < n ; ++i) {
+        Node* node = MR_GetNode(view[i].id);
+        if (!node) {
+            RedisModule_Log(mr_staticCtx, "notice",
+                "Topology reconcile saw a new shard %s; doing a full topology refresh", view[i].id);
+            mr_dictRelease(seen);
+            return false;
+        }
+        if (strcmp(node->ip, view[i].ip) != 0 ||
+            (view[i].port != 0 && node->port != view[i].port)) {
+            RedisModule_Log(mr_staticCtx, "notice",
+                "Topology reconcile: shard %s changed its address; doing a full topology refresh", view[i].id);
+            mr_dictRelease(seen);
+            return false;
+        }
+        mr_dictAdd(seen, (void*)view[i].id, NULL); /* duplicate ranges for a shard are ignored */
+    }
+    size_t shardsNow = mr_dictSize(seen);
+    mr_dictRelease(seen);
+    if (shardsNow != mr_dictSize(clusterCtx.CurrCluster->nodes)) {
+        RedisModule_Log(mr_staticCtx, "notice",
+            "Topology reconcile: the set of shards changed; doing a full topology refresh");
+        return false;
+    }
+
+    /* Pass 2: apply -- repoint the whole slot map; the reused nodes keep their
+     * connections. */
+    memset(clusterCtx.CurrCluster->slots, 0, sizeof(clusterCtx.CurrCluster->slots));
+    bool mySlotsSet = false;
+    for (size_t i = 0 ; i < n ; ++i) {
+        Node* node = MR_GetNode(view[i].id);
+        if (node->isMe && !mySlotsSet) {
+            /* fill the fallback single-range from my first range, like the
+             * full builders do */
+            clusterCtx.minSlot = view[i].minSlot;
+            clusterCtx.maxSlot = view[i].maxSlot;
+            mySlotsSet = true;
+        }
+        for (long long k = view[i].minSlot ; k <= view[i].maxSlot ; ++k) {
+            clusterCtx.CurrCluster->slots[k] = node;
+        }
+    }
+    return true;
+}
+
+/* Reconcile against the current cluster state: rebuild the connections only
+ * when the set of masters (or one of their addresses) changed; otherwise just
+ * repoint the slot map in place and keep the existing connections. */
+static void MR_UpdateClusterSlots(){
     if(!(RedisModule_GetContextFlags(mr_staticCtx) & REDISMODULE_CTX_FLAGS_CLUSTER)){
         return;
     }
 
-    RedisModule_ThreadSafeContextLock(mr_staticCtx);
-    RedisModuleCallReply *allSlotsReply = RedisModule_Call(mr_staticCtx, "cluster", "c", "slots");
-    RedisModule_ThreadSafeContextUnlock(mr_staticCtx);
-    RedisModule_Assert(RedisModule_CallReplyType(allSlotsReply) == REDISMODULE_REPLY_ARRAY);
-
-    /* Repoint the whole slot map from the fresh reply; reused nodes keep their
-     * connections. Runs on the event-loop thread, same as the dispatch path that
-     * reads slots[], so no reader can observe a half-updated map. */
-    memset(clusterCtx.CurrCluster->slots, 0, sizeof(clusterCtx.CurrCluster->slots));
-
-    /* Distinct primaries seen in the fresh reply, so we can detect a primary that
-     * *left* the serving set after the loop (a primary that *entered* is caught
-     * inline below as an unknown shard id). */
-    mr_dict* seenPrimaries = mr_dictCreate(&mr_dictTypeHeapStrings, NULL);
-
-    for(size_t i = 0 ; i < RedisModule_CallReplyLength(allSlotsReply) ; ++i){
-        RedisModuleCallReply *slotRangeReply = RedisModule_CallReplyArrayElement(allSlotsReply, i);
-
-        RedisModuleCallReply *minSlotReply = RedisModule_CallReplyArrayElement(slotRangeReply, 0);
-        RedisModule_Assert(RedisModule_CallReplyType(minSlotReply) == REDISMODULE_REPLY_INTEGER);
-        long long minSlot = RedisModule_CallReplyInteger(minSlotReply);
-
-        RedisModuleCallReply *maxSlotReply = RedisModule_CallReplyArrayElement(slotRangeReply, 1);
-        RedisModule_Assert(RedisModule_CallReplyType(maxSlotReply) == REDISMODULE_REPLY_INTEGER);
-        long long maxSlot = RedisModule_CallReplyInteger(maxSlotReply);
-
-        RedisModuleCallReply *nodeDetailsReply = RedisModule_CallReplyArrayElement(slotRangeReply, 2);
-        RedisModule_Assert(RedisModule_CallReplyType(nodeDetailsReply) == REDISMODULE_REPLY_ARRAY);
-        RedisModule_Assert(RedisModule_CallReplyLength(nodeDetailsReply) >= 3);
-        RedisModuleCallReply *nodeidReply = RedisModule_CallReplyArrayElement(nodeDetailsReply, 2);
-        size_t idLen;
-        const char* id = RedisModule_CallReplyStringPtr(nodeidReply,&idLen);
-
-        char nodeId[REDISMODULE_NODE_ID_LEN + 1];
-        memcpy(nodeId, id, REDISMODULE_NODE_ID_LEN);
-        nodeId[REDISMODULE_NODE_ID_LEN] = '\0';
-
-        Node* n = MR_GetNode(nodeId);
-        if(!n){
-            /* A primary entered the serving set -> rebuild so it gets connected. */
-            RedisModule_Log(mr_staticCtx, "notice",
-                "Topology reconcile saw a new shard %s; doing a full topology refresh", nodeId);
-            mr_dictRelease(seenPrimaries);
-            RedisModule_FreeCallReply(allSlotsReply);
-            MR_RefreshClusterData();
-            return;
-        }
-
-        /* Same id but a new address (the node restarted elsewhere, e.g. a pod
-         * reschedule that kept nodes.conf): the cached connection would redial
-         * the old address forever, so rebuild to reconnect. The port is taken
-         * from RedisModule_GetClusterNodeInfo for the same reason as in
-         * MR_RefreshClusterData (CLUSTER SLOTS reports the non-TLS port, see
-         * redis/redis#12233). */
-        RedisModuleCallReply *nodeipReply = RedisModule_CallReplyArrayElement(nodeDetailsReply, 0);
-        size_t ipLen;
-        const char* ip = RedisModule_CallReplyStringPtr(nodeipReply, &ipLen);
-        int port = 0;
-        RedisModule_ThreadSafeContextLock(mr_staticCtx);
-        RedisModule_GetClusterNodeInfo(mr_staticCtx, nodeId, NULL, NULL, &port, NULL);
-        RedisModule_ThreadSafeContextUnlock(mr_staticCtx);
-        if (strlen(n->ip) != ipLen || memcmp(n->ip, ip, ipLen) != 0 ||
-            (port != 0 && n->port != (unsigned short)port)) {
-            RedisModule_Log(mr_staticCtx, "notice",
-                "Topology reconcile: shard %s changed its address; doing a full topology refresh", nodeId);
-            mr_dictRelease(seenPrimaries);
-            RedisModule_FreeCallReply(allSlotsReply);
-            MR_RefreshClusterData();
-            return;
-        }
-        mr_dictAdd(seenPrimaries, nodeId, NULL); /* duplicate ranges for a node are ignored */
-
-        if (n->isMe) {
-            clusterCtx.minSlot = minSlot;
-            clusterCtx.maxSlot = maxSlot;
-        }
-
-        for(int k = minSlot ; k <= maxSlot ; ++k){
-            clusterCtx.CurrCluster->slots[k] = n;
-        }
-    }
-    RedisModule_FreeCallReply(allSlotsReply);
-
-    /* If a primary we knew about is no longer serving any slots (scale-in / failover),
-     * the set of primaries shrank -- rebuild so we drop it and abort in-flight
-     * executions that assumed it. Additions were handled above, so a distinct count
-     * smaller than the primaries we hold means exactly a removal. */
-    size_t primariesNow = mr_dictSize(seenPrimaries);
-    mr_dictRelease(seenPrimaries);
-    if (primariesNow != mr_dictSize(clusterCtx.CurrCluster->nodes)) {
-        RedisModule_Log(mr_staticCtx, "notice",
-            "Topology reconcile: the set of primaries changed; doing a full topology refresh");
+    ARR(TopologyViewEntry) view = BuildClusterApiView(false);
+    bool applied = view != NULL && MR_TryApplyTopologyInPlace(view, array_len(view));
+    if (view)
+        array_free(view);
+    if (!applied)
         MR_RefreshClusterData();
-        return;
-    }
 }
 
 static void GenerateRunId(Cluster* cluster){
@@ -1455,27 +1453,19 @@ static int MR_ClusterRefresh(RedisModuleCtx *ctx, RedisModuleString **argv, int 
     return REDISMODULE_OK;
 }
 
-/* Runs on the event loop. MR_UpdateClusterSlots decides from the actual
- * primary-set delta whether a full rebuild (which aborts in-flight executions)
- * is needed or a connection-preserving in-place slot-map update suffices, so a
- * redundant event costs one CLUSTER SLOTS read and never drops in-flight
- * multi-key commands. */
+/* Runs on the event loop. */
 static void MR_TopoRefreshTask(void* ctx){
     REDISMODULE_NOT_USED(ctx);
     MR_UpdateClusterSlots();
 }
 
 /* Request an OSS cluster topology refresh; every event schedules one reconcile
- * on the event loop. No-op when not running as an OSS cluster
- * (Enterprise/standalone), mirroring the OSS-only registration of the
- * REFRESHCLUSTER command, so it is safe to call unconditionally from a Redis
- * server-event callback. */
+ * on the event loop. No-op when not in OSS cluster mode, so it is safe to call
+ * unconditionally from a Redis server-event callback. */
 void MR_ClusterRefreshTopology(int change_flags){
     if (!clusterCtx.isOss) return;
-    /* change_flags is advisory: the refresh reconciles against CLUSTER SLOTS
-     * and decides rebuild-vs-in-place from the actual primary-set delta, so we
-     * don't act on the reason bits here. Kept in the signature for callers /
-     * future use. */
+    /* change_flags is advisory: the refresh compares the actual master set, so
+     * the reason bits are not acted on. */
     REDISMODULE_NOT_USED(change_flags);
     MR_EventLoopAddTask(MR_TopoRefreshTask, NULL);
 }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1323,6 +1323,65 @@ static int MR_ClusterRefresh(RedisModuleCtx *ctx, RedisModuleString **argv, int 
     return REDISMODULE_OK;
 }
 
+/* Trailing debounce for the automatic topology refresh. A reshard issues
+ * CLUSTER SETSLOT per slot, so the topology-change event can fire thousands of
+ * times in quick succession; a naive refresh-per-event would tear down and
+ * rebuild every inter-shard connection thousands of times (MR_RefreshClusterData
+ * frees the whole cluster), which is both wasteful and disruptive to in-flight
+ * cross-shard queries. Instead every event just bumps a counter; an event-loop
+ * task reschedules itself until the counter stops advancing for one debounce
+ * window, then does a single refresh. Net effect: one refresh per burst. */
+#define MR_TOPOLOGY_DEBOUNCE_MS 100
+
+static unsigned long long clusterTopoEventSeq = 0; /* bumped by the event callback */
+static char clusterTopoDebounceArmed = 0;          /* at most one debounce chain */
+static unsigned long long clusterTopoSeenSeq = 0;  /* event-loop thread only */
+
+/* Runs on the event loop. Refreshes once the event counter has been stable for
+ * a full debounce window, otherwise waits another window. */
+static void MR_TopoDebounceCheck(void* ctx){
+    REDISMODULE_NOT_USED(ctx);
+    unsigned long long cur = __atomic_load_n(&clusterTopoEventSeq, __ATOMIC_SEQ_CST);
+    if (cur != clusterTopoSeenSeq) {
+        /* More events arrived during the window; keep waiting. */
+        clusterTopoSeenSeq = cur;
+        MR_EventLoopAddTaskWithDelay(MR_TopoDebounceCheck, NULL, MR_TOPOLOGY_DEBOUNCE_MS);
+        return;
+    }
+    /* Quiesced. Disarm, then re-check so an event that raced in just now is not
+     * lost (it would otherwise see the armed flag set and not start a chain). */
+    __atomic_clear(&clusterTopoDebounceArmed, __ATOMIC_SEQ_CST);
+    if (__atomic_load_n(&clusterTopoEventSeq, __ATOMIC_SEQ_CST) != cur) {
+        if (!__atomic_test_and_set(&clusterTopoDebounceArmed, __ATOMIC_SEQ_CST)) {
+            clusterTopoSeenSeq = __atomic_load_n(&clusterTopoEventSeq, __ATOMIC_SEQ_CST);
+            MR_EventLoopAddTaskWithDelay(MR_TopoDebounceCheck, NULL, MR_TOPOLOGY_DEBOUNCE_MS);
+        }
+        return;
+    }
+    MR_RefreshClusterData();
+}
+
+/* Runs on the event loop: start a debounce chain (called via the thread-safe
+ * MR_EventLoopAddTask so the delayed timer is armed from the loop thread). */
+static void MR_TopoDebounceStart(void* ctx){
+    REDISMODULE_NOT_USED(ctx);
+    clusterTopoSeenSeq = __atomic_load_n(&clusterTopoEventSeq, __ATOMIC_SEQ_CST);
+    MR_EventLoopAddTaskWithDelay(MR_TopoDebounceCheck, NULL, MR_TOPOLOGY_DEBOUNCE_MS);
+}
+
+/* Request an OSS cluster topology refresh, debounced. No-op when not running as
+ * an OSS cluster (Enterprise/standalone), mirroring the OSS-only registration of
+ * the REFRESHCLUSTER command, so it is safe to call unconditionally from a Redis
+ * server-event callback. */
+void MR_ClusterRefreshTopology(void){
+    if (!clusterCtx.isOss) return;
+    __atomic_add_fetch(&clusterTopoEventSeq, 1, __ATOMIC_SEQ_CST);
+    if (__atomic_test_and_set(&clusterTopoDebounceArmed, __ATOMIC_SEQ_CST)) {
+        return; /* a debounce chain is already running; it will see the bump */
+    }
+    MR_EventLoopAddTask(MR_TopoDebounceStart, NULL);
+}
+
 static int MR_ClusterSet(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
     if (!(IsShortFormClusterSet(argc) || IsLongFormClusterSet(argc))) {
         RedisModule_ReplyWithError(ctx, "Could not parse cluster set arguments");

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1037,6 +1037,29 @@ static void MR_UpdateClusterSlots(){
             MR_RefreshClusterData();
             return;
         }
+
+        /* Same id but a new address (the node restarted elsewhere, e.g. a pod
+         * reschedule that kept nodes.conf): the cached connection would redial
+         * the old address forever, so rebuild to reconnect. The port is taken
+         * from RedisModule_GetClusterNodeInfo for the same reason as in
+         * MR_RefreshClusterData (CLUSTER SLOTS reports the non-TLS port, see
+         * redis/redis#12233). */
+        RedisModuleCallReply *nodeipReply = RedisModule_CallReplyArrayElement(nodeDetailsReply, 0);
+        size_t ipLen;
+        const char* ip = RedisModule_CallReplyStringPtr(nodeipReply, &ipLen);
+        int port = 0;
+        RedisModule_ThreadSafeContextLock(mr_staticCtx);
+        RedisModule_GetClusterNodeInfo(mr_staticCtx, nodeId, NULL, NULL, &port, NULL);
+        RedisModule_ThreadSafeContextUnlock(mr_staticCtx);
+        if (strlen(n->ip) != ipLen || memcmp(n->ip, ip, ipLen) != 0 ||
+            (port != 0 && n->port != (unsigned short)port)) {
+            RedisModule_Log(mr_staticCtx, "notice",
+                "Topology reconcile: shard %s changed its address; doing a full topology refresh", nodeId);
+            mr_dictRelease(seenPrimaries);
+            RedisModule_FreeCallReply(allSlotsReply);
+            MR_RefreshClusterData();
+            return;
+        }
         mr_dictAdd(seenPrimaries, nodeId, NULL); /* duplicate ranges for a node are ignored */
 
         if (n->isMe) {

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -955,27 +955,33 @@ static void MR_RefreshClusterData(){
     mr_dictEmpty(clusterCtx.nodesMsgIds, NULL);
 }
 
-/* Update only the slot->node routing from a fresh CLUSTER SLOTS, reusing the
- * existing Node structs (and their live connections) instead of tearing the whole
- * cluster down and reconnecting. Used for an in-place reshard (only the
- * REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_SLOT reason set): the set of primaries is unchanged,
- * so only the slot map moved. A full MR_RefreshClusterData would abort in-flight
- * cross-shard executions (MR_AbortRunningExecutions) and rebuild every connection
- * for nothing, which is exactly what disrupts fan-out queries running during a
- * reshard.
+/* Reconcile the LibMR cluster view with a fresh CLUSTER SLOTS, reusing the existing
+ * Node structs (and their live connections) wherever possible. This is the single
+ * entry point the debounced topology-change handler calls, regardless of which
+ * reason flags the event carried, and it decides what to do from the actual
+ * primary-set delta:
+ *
+ *  - If the set of slot-serving primaries is unchanged (only slot ownership moved
+ *    between primaries we are already connected to -- an in-place reshard), we just
+ *    repoint CurrCluster->slots in place. Connections and in-flight cross-shard
+ *    executions are left untouched, so a reshard never drops multi-key commands.
+ *  - If the set of primaries changed (a primary entered or left the serving set --
+ *    scale-out, scale-in, failover), we escalate to MR_RefreshClusterData, which
+ *    reconnects to the new set and aborts in-flight executions (the client retries).
+ *
+ * Deciding by the primary-set delta rather than by the event's reason flags means an
+ * over-broad or spurious notification (a replica re-pointing, an OK<->FAIL flip, a
+ * slotless node joining) that does not change the primary set costs only a cheap
+ * in-place repoint -- never a connection rebuild or a dropped in-flight multi-key
+ * command.
  *
  * In OSS mode CurrCluster->slots is the routing source of truth (the SendMsgType_BySlot
- * path), while fan-out (SendMsgType_All) iterates the nodes dict -- both stay correct
- * here since the node set is unchanged and only slots[] is repointed. Per-node
- * slotRanges are only consumed by the Enterprise CLUSTERSET build and the debug
- * RG.INFOCLUSTER reply, so they are intentionally left untouched.
- *
- * If a primary we have never seen appears, the change was not purely slot-level
- * after all (a node entered the serving set); fall back to a full rebuild so the
- * new shard is set up and connected through the normal path. */
+ * path) and fan-out (SendMsgType_All) iterates the nodes dict; both stay correct here.
+ * Per-node slotRanges are only consumed by the Enterprise CLUSTERSET build and the
+ * debug RG.INFOCLUSTER reply, so they are intentionally left untouched. */
 static void MR_UpdateClusterSlots(){
     if (!clusterCtx.CurrCluster) {
-        /* Nothing to update incrementally yet; build from scratch. */
+        /* Nothing to reconcile against yet; build from scratch. */
         MR_RefreshClusterData();
         return;
     }
@@ -983,8 +989,6 @@ static void MR_UpdateClusterSlots(){
     if(!(RedisModule_GetContextFlags(mr_staticCtx) & REDISMODULE_CTX_FLAGS_CLUSTER)){
         return;
     }
-
-    RedisModule_Log(mr_staticCtx, "notice", "Got cluster slot-map update (in-place reshard)");
 
     RedisModule_ThreadSafeContextLock(mr_staticCtx);
     RedisModuleCallReply *allSlotsReply = RedisModule_Call(mr_staticCtx, "cluster", "c", "slots");
@@ -995,6 +999,11 @@ static void MR_UpdateClusterSlots(){
      * connections. Runs on the event-loop thread, same as the dispatch path that
      * reads slots[], so no reader can observe a half-updated map. */
     memset(clusterCtx.CurrCluster->slots, 0, sizeof(clusterCtx.CurrCluster->slots));
+
+    /* Distinct primaries seen in the fresh reply, so we can detect a primary that
+     * *left* the serving set after the loop (a primary that *entered* is caught
+     * inline below as an unknown shard id). */
+    mr_dict* seenPrimaries = mr_dictCreate(&mr_dictTypeHeapStrings, NULL);
 
     for(size_t i = 0 ; i < RedisModule_CallReplyLength(allSlotsReply) ; ++i){
         RedisModuleCallReply *slotRangeReply = RedisModule_CallReplyArrayElement(allSlotsReply, i);
@@ -1020,13 +1029,15 @@ static void MR_UpdateClusterSlots(){
 
         Node* n = MR_GetNode(nodeId);
         if(!n){
-            /* A primary we did not know about -> not a pure slot move after all. */
+            /* A primary entered the serving set -> rebuild so it gets connected. */
             RedisModule_Log(mr_staticCtx, "notice",
-                "Slot-map update saw an unknown shard %s; doing a full topology refresh", nodeId);
+                "Topology reconcile saw a new shard %s; doing a full topology refresh", nodeId);
+            mr_dictRelease(seenPrimaries);
             RedisModule_FreeCallReply(allSlotsReply);
             MR_RefreshClusterData();
             return;
         }
+        mr_dictAdd(seenPrimaries, nodeId, NULL); /* duplicate ranges for a node are ignored */
 
         if (n->isMe) {
             clusterCtx.minSlot = minSlot;
@@ -1038,6 +1049,19 @@ static void MR_UpdateClusterSlots(){
         }
     }
     RedisModule_FreeCallReply(allSlotsReply);
+
+    /* If a primary we knew about is no longer serving any slots (scale-in / failover),
+     * the set of primaries shrank -- rebuild so we drop it and abort in-flight
+     * executions that assumed it. Additions were handled above, so a distinct count
+     * smaller than the primaries we hold means exactly a removal. */
+    size_t primariesNow = mr_dictSize(seenPrimaries);
+    mr_dictRelease(seenPrimaries);
+    if (primariesNow != mr_dictSize(clusterCtx.CurrCluster->nodes)) {
+        RedisModule_Log(mr_staticCtx, "notice",
+            "Topology reconcile: the set of primaries changed; doing a full topology refresh");
+        MR_RefreshClusterData();
+        return;
+    }
 }
 
 static void GenerateRunId(Cluster* cluster){
@@ -1421,20 +1445,6 @@ static int MR_ClusterRefresh(RedisModuleCtx *ctx, RedisModuleString **argv, int 
 static unsigned long long clusterTopoEventSeq = 0; /* bumped by the event callback */
 static char clusterTopoDebounceArmed = 0;          /* at most one debounce chain */
 static unsigned long long clusterTopoSeenSeq = 0;  /* event-loop thread only */
-/* OR of REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_* reasons accumulated across the
- * events coalesced into the current debounce window, so we can pick the cheapest
- * refresh that still covers every change. */
-static unsigned int clusterTopoPendingChanges = 0;
-
-/* Reasons that may change the set of primaries we hold connections to -- a node
- * joined/left (NODE), a primary/replica role flip (ROLE), or an OK/FAIL transition
- * that can bring shards in or out of service (STATE) -- and therefore require a
- * full rebuild (reconnect). A SLOT-only change is an in-place reshard between
- * primaries we are already connected to, so a connection-preserving slot-map
- * update suffices and avoids aborting in-flight cross-shard queries. */
-#define MR_TOPO_REBUILD_FLAGS (REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE | \
-                               REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_ROLE | \
-                               REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_STATE)
 
 /* Runs on the event loop. Refreshes once the event counter has been stable for
  * a full debounce window, otherwise waits another window. */
@@ -1457,20 +1467,14 @@ static void MR_TopoDebounceCheck(void* ctx){
         }
         return;
     }
-    /* Quiesced for real. Consume the accumulated reason flags and pick the cheapest
-     * refresh that covers them: a full rebuild if the set of primaries may have
-     * changed (NODE/ROLE/STATE), otherwise a connection-preserving slot-map update
-     * for an in-place reshard (SLOT only). If a rebuild-worthy event raced in after
-     * the re-check above, it re-armed its own chain and re-OR'd its bit; whichever
-     * exchange observes the bit does the full rebuild, and the other chain's refresh
-     * is a harmless idempotent slot-map update -- so a membership/role/state change
-     * is never masked by this fast path. */
-    unsigned int pending = __atomic_exchange_n(&clusterTopoPendingChanges, 0u, __ATOMIC_SEQ_CST);
-    if (pending & MR_TOPO_REBUILD_FLAGS) {
-        MR_RefreshClusterData();
-    } else {
-        MR_UpdateClusterSlots();
-    }
+    /* Quiesced for real. Reconcile against CLUSTER SLOTS: MR_UpdateClusterSlots
+     * decides from the actual primary-set delta whether a full rebuild (which aborts
+     * in-flight executions) is needed or a connection-preserving in-place slot-map
+     * update suffices. The event's reason flags therefore don't need to be exact,
+     * and a spurious/over-broad event never drops in-flight multi-key commands. If an
+     * event raced in after the re-check above it re-armed its own chain; a redundant
+     * reconcile is a harmless no-op. */
+    MR_UpdateClusterSlots();
 }
 
 /* Runs on the event loop: start a debounce chain (called via the thread-safe
@@ -1487,10 +1491,11 @@ static void MR_TopoDebounceStart(void* ctx){
  * server-event callback. */
 void MR_ClusterRefreshTopology(int change_flags){
     if (!clusterCtx.isOss) return;
-    /* Accumulate the reason flags before bumping the sequence, so the debounce task
-     * that eventually fires always sees at least the bits for every event it is
-     * coalescing. */
-    __atomic_or_fetch(&clusterTopoPendingChanges, (unsigned int)change_flags, __ATOMIC_SEQ_CST);
+    /* change_flags is advisory: the debounced refresh reconciles against CLUSTER
+     * SLOTS and decides rebuild-vs-in-place from the actual primary-set delta, so we
+     * don't act on the reason bits here. Kept in the signature for callers / future
+     * use. */
+    REDISMODULE_NOT_USED(change_flags);
     __atomic_add_fetch(&clusterTopoEventSeq, 1, __ATOMIC_SEQ_CST);
     if (__atomic_test_and_set(&clusterTopoDebounceArmed, __ATOMIC_SEQ_CST)) {
         return; /* a debounce chain is already running; it will see the bump */

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -37,11 +37,11 @@ size_t MR_ClusterGetSize();
 
 int MR_ClusterInit(RedisModuleCtx* rctx, char *password);
 
-/* Schedule an OSS cluster topology refresh on the event loop, debounced.
- * 'change_flags' is a bitmask of REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_*
- * describing the reasons for the change: a NODE/ROLE/STATE reason triggers a full
- * rebuild (reconnecting to the possibly-changed set of primaries), while a
- * SLOT-only change updates just the slot->node routing and preserves the existing
+/* Schedule an OSS cluster topology refresh on the event loop. 'change_flags'
+ * is a bitmask of REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_* reasons and is
+ * advisory only: the refresh reconciles against CLUSTER SLOTS and rebuilds the
+ * connections only when the set of slot-serving primaries actually changed,
+ * otherwise it updates just the slot->node routing and preserves the existing
  * connections (so in-flight cross-shard queries are not disrupted by an in-place
  * reshard). No-op outside of OSS cluster mode. Safe to call from a Redis
  * server-event callback. */

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -39,12 +39,10 @@ int MR_ClusterInit(RedisModuleCtx* rctx, char *password);
 
 /* Schedule an OSS cluster topology refresh on the event loop. 'change_flags'
  * is a bitmask of REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_* reasons and is
- * advisory only: the refresh reconciles against CLUSTER SLOTS and rebuilds the
- * connections only when the set of slot-serving primaries actually changed,
- * otherwise it updates just the slot->node routing and preserves the existing
- * connections (so in-flight cross-shard queries are not disrupted by an in-place
- * reshard). No-op outside of OSS cluster mode. Safe to call from a Redis
- * server-event callback. */
+ * advisory only: the refresh rebuilds the connections when the set of master
+ * nodes changed and otherwise just updates the slot->node routing in place.
+ * No-op outside of OSS cluster mode. Safe to call from a Redis server-event
+ * callback. */
 void MR_ClusterRefreshTopology(int change_flags);
 
 size_t MR_ClusterGetSlotByKey(const char* key, size_t len);

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -37,6 +37,10 @@ size_t MR_ClusterGetSize();
 
 int MR_ClusterInit(RedisModuleCtx* rctx, char *password);
 
+/* Schedule an OSS cluster topology refresh on the event loop. No-op outside of
+ * OSS cluster mode. Safe to call from a Redis server-event callback. */
+void MR_ClusterRefreshTopology(void);
+
 size_t MR_ClusterGetSlotByKey(const char* key, size_t len);
 
 int MR_ClusterIsMySlot(size_t slot);

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -37,9 +37,15 @@ size_t MR_ClusterGetSize();
 
 int MR_ClusterInit(RedisModuleCtx* rctx, char *password);
 
-/* Schedule an OSS cluster topology refresh on the event loop. No-op outside of
- * OSS cluster mode. Safe to call from a Redis server-event callback. */
-void MR_ClusterRefreshTopology(void);
+/* Schedule an OSS cluster topology refresh on the event loop, debounced.
+ * 'change_flags' is a bitmask of REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_*
+ * describing the reasons for the change: a NODE/ROLE/STATE reason triggers a full
+ * rebuild (reconnecting to the possibly-changed set of primaries), while a
+ * SLOT-only change updates just the slot->node routing and preserves the existing
+ * connections (so in-flight cross-shard queries are not disrupted by an in-place
+ * reshard). No-op outside of OSS cluster mode. Safe to call from a Redis
+ * server-event callback. */
+void MR_ClusterRefreshTopology(int change_flags);
 
 size_t MR_ClusterGetSlotByKey(const char* key, size_t len);
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -736,10 +736,8 @@ static const RedisModuleEvent
 #define REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_TRIM_BACKGROUND 2
 #define _REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_TRIM_NEXT 3
 
-#define REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_STARTUP 0
-#define REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_TOPOLOGY_CHANGED 1
-#define REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_ROLE_CHANGED 2
-#define _REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_NEXT 3
+/* RedisModuleEvent_ClusterTopologyChange has no meaningful subevent. */
+#define _REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_NEXT 0
 
 /* RedisModuleClientInfo flags. */
 #define REDISMODULE_CLIENTINFO_FLAG_SSL (1<<0)
@@ -904,6 +902,26 @@ typedef struct RedisModuleClusterSlotMigrationTrimInfo {
 } RedisModuleClusterSlotMigrationTrimInfoV1;
 
 #define RedisModuleClusterSlotMigrationTrimInfo RedisModuleClusterSlotMigrationTrimInfoV1
+
+/* Reason flags reported in RedisModuleClusterTopologyChangeInfo.change_flags.
+ * More than one bit may be set when several changes were collapsed into a
+ * single (debounced) RedisModuleEvent_ClusterTopologyChange notification. */
+#define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_SLOT  (1<<0) /* Slot ownership changed. */
+#define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_ROLE  (1<<1) /* A node changed its primary/replica role. */
+#define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_STATE (1<<2) /* The cluster OK/FAIL state changed. */
+#define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE  (1<<3) /* A node joined or left the cluster. */
+
+#define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_INFO_VERSION 1
+
+typedef struct RedisModuleClusterTopologyChangeInfo {
+    uint64_t version;       /* Not used since this structure is never passed
+                               from the module to the core right now. Here
+                               for future compatibility. */
+    uint64_t change_flags;  /* Bitmask of REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_*
+                               reasons that contributed to this notification. */
+} RedisModuleClusterTopologyChangeInfoV1;
+
+#define RedisModuleClusterTopologyChangeInfo RedisModuleClusterTopologyChangeInfoV1
 
 typedef enum {
     REDISMODULE_ACL_LOG_AUTH = 0, /* Authentication failure */

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -909,7 +909,7 @@ typedef struct RedisModuleClusterSlotMigrationTrimInfo {
 #define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_SLOT  (1<<0) /* Slot ownership changed. */
 #define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_ROLE  (1<<1) /* A node changed its primary/replica role. */
 #define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_STATE (1<<2) /* The cluster OK/FAIL state changed. */
-#define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE  (1<<3) /* A node joined or left the cluster. */
+#define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE  (1<<3) /* A node joined or left the cluster, or its address changed. */
 
 #define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_INFO_VERSION 1
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -520,7 +520,8 @@ typedef void (*RedisModuleEventLoopOneShotFunc)(void *user_data);
 #define REDISMODULE_EVENT_KEY 17
 #define REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION 18
 #define REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION_TRIM 19
-#define _REDISMODULE_EVENT_NEXT 20 /* Next event flag, should be updated if a new event added. */
+#define REDISMODULE_EVENT_CLUSTER_TOPOLOGY_CHANGE 20
+#define _REDISMODULE_EVENT_NEXT 21 /* Next event flag, should be updated if a new event added. */
 
 typedef struct RedisModuleEvent {
     uint64_t id;        /* REDISMODULE_EVENT_... defines. */
@@ -639,6 +640,10 @@ static const RedisModuleEvent
     RedisModuleEvent_ClusterSlotMigrationTrim = {
         REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION_TRIM,
         1
+    },
+    RedisModuleEvent_ClusterTopologyChange = {
+        REDISMODULE_EVENT_CLUSTER_TOPOLOGY_CHANGE,
+        1
     };
 
 /* Those are values that are used for the 'subevent' callback argument. */
@@ -730,6 +735,11 @@ static const RedisModuleEvent
 #define REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_TRIM_COMPLETED 1
 #define REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_TRIM_BACKGROUND 2
 #define _REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_TRIM_NEXT 3
+
+#define REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_STARTUP 0
+#define REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_TOPOLOGY_CHANGED 1
+#define REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_ROLE_CHANGED 2
+#define _REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_NEXT 3
 
 /* RedisModuleClientInfo flags. */
 #define REDISMODULE_CLIENTINFO_FLAG_SSL (1<<0)


### PR DESCRIPTION
## Summary

Adds **`MR_ClusterRefreshTopology()`** so a consumer module can refresh the LibMR cluster view in response to a Redis server event, instead of requiring an operator to call a manual refresh command (e.g. `TIMESERIES.REFRESHCLUSTER`) on every primary after each reshard.

### What it does

- `MR_ClusterRefreshTopology()` schedules the existing `MR_RefreshClusterData()` on the LibMR event loop (the thread-safe place to mutate topology), with **no blocked client** to reply to — the difference from the command-driven `MR_ClusterRefresh`.
- It is **gated by `clusterCtx.isOss`**, so it is a no-op outside OSS cluster mode (under Enterprise the DMC drives topology via `CLUSTERSET`), mirroring the OSS-only registration of `REFRESHCLUSTER`. Safe to call unconditionally from an event callback.
- Declared in `cluster.h` next to the other `MR_Cluster*` entry points.

The local `redismodule.h` copy is updated with the `RedisModuleEvent_ClusterTopologyChange` definitions (id 20) so LibMR consumers compile against the new event; this mirrors redis/redis#15350 and will be reconciled by the normal header sync.

Used by the RedisTimeSeries consumer PR (auto-refresh on cluster topology change). Verified end-to-end on a 3-node OSS cluster: topology auto-refreshes on formation and reshard with no manual command.

Depends on / mirrors: redis/redis#15350
Relates-to: MOD-9152, RED-148990

> Draft — gated on the core event being finalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OSS cluster slot routing and when inter-shard connections are torn down; incorrect reconcile could misroute cross-shard traffic until a full refresh runs.
> 
> **Overview**
> Adds **`MR_ClusterRefreshTopology()`** so consumer modules can refresh LibMR’s cluster view from **`RedisModuleEvent_ClusterTopologyChange`** (and related server events) without a manual **`REFRESHCLUSTER`** on every primary. The call is **OSS-only** (`clusterCtx.isOss`), ignores advisory `change_flags`, and queues work on the LibMR event loop so it is safe from a Redis server-event callback.
> 
> Reconciliation is **`MR_UpdateClusterSlots()`**: it builds a master/slot view from the same cluster module APIs as short-form **`CLUSTERSET`** (`BuildClusterApiView`). When the master set and addresses are unchanged, **`MR_TryApplyTopologyInPlace()`** clears and repoints **`slots[]`** while keeping existing shard connections; otherwise it falls back to the existing full **`MR_RefreshClusterData()`** teardown/rebuild.
> 
> The vendored **`redismodule.h`** gains **`RedisModuleEvent_ClusterTopologyChange`**, topology change reason flags, and **`RedisModuleClusterTopologyChangeInfo`** so LibMR consumers can compile against the new event (aligned with redis/redis#15350).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f4bc06e189ddecaf64cbf736e536cd192f713ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->