### PR TITLE
MOD-15749 Short-form CLUSTERSET: reject when the cluster API has no usable node endpoints

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1138,18 +1138,31 @@ static int SetClusterDataShortForm(RedisModuleString** argv, int argc){
         memcpy(nodeId, nodeList[i], REDISMODULE_NODE_ID_LEN);
         nodeId[REDISMODULE_NODE_ID_LEN] = '\0';
 
-        char ip[INET6_ADDRSTRLEN];  // INET6_ADDRSTRLEN includes the closing '\0'
-        int port, flags;
+        char ip[INET6_ADDRSTRLEN] = {0};  // INET6_ADDRSTRLEN includes the closing '\0'
+        int port = 0, flags = 0;
 
-        if (RedisModule_GetClusterNodeInfo(mr_staticCtx, nodeId, ip, NULL, &port, &flags) != REDISMODULE_OK) {
-            RedisModule_Log(mr_staticCtx, "warning", "Failed to get info for node %s", nodeId);
+        // The cluster API may list a node for which it has no usable endpoint: GetClusterNodeInfo
+        // can fail, or return a zero/empty ip:port. This happens on Redis builds where the module
+        // cluster topology is not fully populated -- e.g. Redis Enterprise without the node-port
+        // backport, where getNodeDefaultClientPort() returns 0 (RED-202230). Skip such nodes; if
+        // none remain we reject the command below so the caller can fall back to the long form.
+        if (RedisModule_GetClusterNodeInfo(mr_staticCtx, nodeId, ip, NULL, &port, &flags) != REDISMODULE_OK
+            || port <= 0 || ip[0] == '\0') {
+            RedisModule_Log(mr_staticCtx, "warning",
+                "Short-form CLUSTERSET: no valid endpoint for node %s (ip/port not set by the cluster API)", nodeId);
             continue;
         }
 
         if (!(flags & REDISMODULE_NODE_MASTER)) continue;  // Skip replica nodes
 
         RedisModuleSlotRangeArray *slots = RedisModule_GetClusterNodeSlotRanges(mr_staticCtx, nodeId);
-        RedisModule_Assert(slots != NULL);
+        if (slots == NULL) {
+            // Defensive: don't crash the shard if the API returns no slot info for a node it just
+            // listed (incomplete topology); skip it instead of asserting.
+            RedisModule_Log(mr_staticCtx, "warning",
+                "Short-form CLUSTERSET: no slot ranges for node %s; skipping", nodeId);
+            continue;
+        }
         long long minSlot = 0, maxSlot = -1;  // min > max indicates a no-hslots range (i.e., used for slotless shards)
         if (slots->num_ranges > 0) {
             minSlot = slots->ranges[0].start;
@@ -1181,6 +1194,18 @@ static int SetClusterDataShortForm(RedisModuleString** argv, int argc){
         RedisModule_ClusterFreeSlotRanges(mr_staticCtx, slots);
     }
     RedisModule_FreeClusterNodesList(nodeList);
+
+    // If the cluster API gave us no usable master shards (e.g. every node had a zero/empty
+    // endpoint), reject the short form instead of installing an empty/broken topology and
+    // replying OK. Returning an error lets the caller (e.g. DMC) fall back to the long-form
+    // CLUSTERSET, which carries the endpoints explicitly. See RED-202230.
+    if (mr_dictSize(clusterCtx.CurrCluster->nodes) == 0) {
+        RedisModule_Log(mr_staticCtx, "warning",
+            "Short-form CLUSTERSET produced no valid shards from the cluster API; rejecting so the "
+            "caller can fall back to long-form CLUSTERSET");
+        MR_ClusterFree();  // frees the half-built cluster and sets clusterCtx.CurrCluster = NULL
+        return REDISMODULE_ERR;
+    }
 
     clusterCtx.clusterSize = mr_dictSize(clusterCtx.CurrCluster->nodes);
     mr_dictEmpty(clusterCtx.nodesMsgIds, NULL);


### PR DESCRIPTION
## Problem

The short form of `CLUSTERSET` derives each shard's `ip:port` from `RedisModule_GetClusterNodeInfo`. On Redis builds where the **module cluster topology isn't fully populated** — notably **Redis Enterprise without the node-port backport**, where `getNodeDefaultClientPort()` returns `0` (**[RED-202230](https://redislabs.atlassian.net/browse/RED-202230)**) — that API yields **no usable endpoint** (port `0` / empty ip), and today's code:

- doesn't validate the port/ip (only checks `rc != REDISMODULE_OK`), so it builds nodes pointing at **port 0** — or skips all nodes and builds an **empty topology**;
- still `return REDISMODULE_OK`, so the caller (DMC) gets `+OK`, believes the cluster is configured, and **never falls back** to the long form → cross-shard commands silently break;
- `RedisModule_Assert(slots != NULL)` can **crash the shard** outright.

RediSearch hit exactly this in RE and fails *loudly* (returns an "invalid topology" error). LibMR currently fails *silently* — worse.

## Fix

Mirror RediSearch's defensive handling in `SetClusterDataShortForm`:
1. Skip nodes with no usable endpoint (`rc != OK || port <= 0 || ip[0] == '\0'`); zero-init the locals so the check is reliable.
2. Replace `RedisModule_Assert(slots != NULL)` with a soft skip (no field crash).
3. If **no valid master shards** remain, `MR_ClusterFree()` and **return an error** so the caller can fall back to the long-form CLUSTERSET (which carries endpoints explicitly).

This does **not** make the short form work in RE (that needs the core fix, RED-202230). It makes the module **fail safely** there — return an error instead of silently installing a broken topology — which is a prerequisite for DMC's try-then-fallback.

## Testing

`cluster.c` compiles and `libmr.a` links clean. The new paths require the RE port bug to exercise (no OSS redis returns port 0), so they're covered by code review here + the enterprise beta; the existing `testShortFormClusterSetWithoutSlotRangesApi` (no-API path) and the RedisTimeSeries oss-cluster flow test (success path) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster topology installation for a critical cross-shard path; behavior is more defensive but alters success/failure when the cluster API is incomplete (e.g. enterprise without port backport).
> 
> **Overview**
> **Short-form `CLUSTERSET`** in `SetClusterDataShortForm` no longer treats a partially empty Redis module cluster API as success.
> 
> Nodes are skipped when `RedisModule_GetClusterNodeInfo` fails or returns an empty IP or non-positive port (e.g. Redis Enterprise without the node-port backport, RED-202230). **`RedisModule_Assert(slots != NULL)`** is replaced with a warning and skip when slot ranges are missing.
> 
> If no valid master shards remain after that pass, the half-built topology is torn down via **`MR_ClusterFree()`** and the function returns **`REDISMODULE_ERR`** so callers like DMC can fall back to long-form **`CLUSTERSET`** instead of replying OK with port-0 or empty topology.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 594375dd1b2508ac58901bf8d8dad87c957ca734. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->