### PR TITLE
MOD-15749 Short-form CLUSTERSET: reject on non-cluster (standalone) shard (RED-207632)

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1107,6 +1107,20 @@ static int SetClusterDataShortForm(RedisModuleString** argv, int argc){
         return REDISMODULE_ERR;
     }
 
+    // The short form derives this shard's own identity and its peers entirely
+    // from the cluster API (GetMyClusterID / GetClusterNodesList /
+    // GetClusterNodeInfo). On a non-cluster (standalone) shard
+    // RedisModule_GetMyClusterID() returns NULL, which would crash while
+    // building the topology (NULL memcpy in SetMyId). Reject the command
+    // instead so the shard stays unconfigured until cluster mode is enabled
+    // (or a long-form CLUSTERSET / REFRESHCLUSTER arrives). See RED-207632.
+    if (!(RedisModule_GetContextFlags(mr_staticCtx) & REDISMODULE_CTX_FLAGS_CLUSTER)) {
+        RedisModule_Log(mr_staticCtx, "warning",
+            "Short-form CLUSTERSET received on a non-cluster (standalone) shard; "
+            "rejecting. The cluster API is unavailable without cluster mode.");
+        return REDISMODULE_ERR;
+    }
+
     clusterCtx.CurrCluster = MR_CALLOC(1, sizeof(*clusterCtx.CurrCluster));
     InitClusterData(clusterCtx.CurrCluster, argv, argc);
     memcpy(clusterCtx.myId, clusterCtx.CurrCluster->myId, REDISMODULE_NODE_ID_LEN + 1);


### PR DESCRIPTION
## Summary
Fixes a **NULL-pointer SIGSEGV** in the LibMR event-loop thread (`timeseries-el`) when a **short-form** `CLUSTERSET` reaches a **non-cluster (standalone)** shard — crash reported in **RED-207632** (`test_asm_happyflow_flag_toggle`, ASM nightly).

## Root cause
`SetClusterDataShortForm` builds the topology entirely from the cluster API. It calls `InitClusterData` → `SetMyId`, which does:

```c
const char* myId = RedisModule_GetMyClusterID();   // NULL when cluster mode is off
...
memcpy(cluster->myId + zerosPadding, myId, myIdLen); // memcpy(dst, NULL, 40) -> SIGSEGV
```

On a standalone shard `RedisModule_GetMyClusterID()` returns `NULL`, so this is `memcpy(dst, NULL, REDISMODULE_NODE_ID_LEN)`. It runs in the event-loop thread because `MR_ClusterSet` schedules `MR_ClusterSetFromCommand` via `MR_EventLoopAddTask`. This matches the crash exactly (faulting thread `timeseries-el`, `RSI=0`, `RDX=0x28` = 40 = `REDISMODULE_NODE_ID_LEN`).

The **long form is unaffected** — it takes `myId` from the command arguments (`argv[CLUSTERSET_MYID_LONG_FORM_INDEX]`), never from `GetMyClusterID()`.

## Fix
Guard the short-form path with the same `REDISMODULE_CTX_FLAGS_CLUSTER` check `MR_RefreshClusterData` already uses: if the shard is not in cluster mode, log a warning and return `REDISMODULE_ERR` (the same failure contract as the sibling "slot-ranges API missing" rejection right above it) instead of crashing. The shard stays unconfigured until cluster mode is enabled or a long-form `CLUSTERSET` / `REFRESHCLUSTER` arrives.

## Verification
- `make -C src/` compiles cleanly with the change.
- Path analysis confirms only the short-form + standalone case is affected; long-form and clustered short-form paths are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive guard on an error path already used elsewhere; long-form and clustered short-form behavior unchanged.
> 
> **Overview**
> Fixes a **SIGSEGV** in the LibMR event-loop thread when **short-form** `CLUSTERSET` is handled on a **standalone** (non-cluster) Redis instance.
> 
> Short-form topology setup calls `SetMyId`, which uses `RedisModule_GetMyClusterID()`; that API returns **NULL** without cluster mode, leading to a NULL `memcpy` and crash. **`SetClusterDataShortForm`** now checks **`REDISMODULE_CTX_FLAGS_CLUSTER`** (same pattern as **`MR_RefreshClusterData`**): if cluster mode is off, it logs a warning and returns **`REDISMODULE_ERR`**, leaving the shard unconfigured until cluster mode is on or a **long-form** `CLUSTERSET` / **`REFRESHCLUSTER`** succeeds.
> 
> Long-form `CLUSTERSET` and short-form on clustered shards are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3020b2ec16e75cba850bc1c9596cc9468660a05a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->