### PR TITLE
MOD-17358 Reject short-form CLUSTERSET when the shard has no cluster identity

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1147,18 +1147,24 @@ static int SetClusterDataShortForm(RedisModuleString** argv, int argc){
         memcpy(nodeId, nodeList[i], REDISMODULE_NODE_ID_LEN);
         nodeId[REDISMODULE_NODE_ID_LEN] = '\0';
 
-        char ip[INET6_ADDRSTRLEN];  // INET6_ADDRSTRLEN includes the closing '\0'
-        int port, flags;
+        char ip[INET6_ADDRSTRLEN] = {0};  // INET6_ADDRSTRLEN includes the closing '\0'
+        int port = 0, flags = 0;
 
-        if (RedisModule_GetClusterNodeInfo(mr_staticCtx, nodeId, ip, NULL, &port, &flags) != REDISMODULE_OK) {
-            RedisModule_Log(mr_staticCtx, "warning", "Failed to get info for node %s", nodeId);
+        // Skip nodes with no usable endpoint (rc != OK, or port/ip unset -- e.g. RE without the
+        // node-port backport, where getNodeDefaultClientPort() returns 0, RED-202230).
+        if (RedisModule_GetClusterNodeInfo(mr_staticCtx, nodeId, ip, NULL, &port, &flags) != REDISMODULE_OK
+            || port <= 0 || ip[0] == '\0') {
+            RedisModule_Log(mr_staticCtx, "warning", "Short-form CLUSTERSET: no valid endpoint for node %s", nodeId);
             continue;
         }
 
         if (!(flags & REDISMODULE_NODE_MASTER)) continue;  // Skip replica nodes
 
         RedisModuleSlotRangeArray *slots = RedisModule_GetClusterNodeSlotRanges(mr_staticCtx, nodeId);
-        RedisModule_Assert(slots != NULL);
+        if (slots == NULL) {  // incomplete topology; skip instead of asserting
+            RedisModule_Log(mr_staticCtx, "warning", "Short-form CLUSTERSET: no slot ranges for node %s; skipping", nodeId);
+            continue;
+        }
         long long minSlot = 0, maxSlot = -1;  // min > max indicates a no-hslots range (i.e., used for slotless shards)
         if (slots->num_ranges > 0) {
             minSlot = slots->ranges[0].start;
@@ -1190,6 +1196,14 @@ static int SetClusterDataShortForm(RedisModuleString** argv, int argc){
         RedisModule_ClusterFreeSlotRanges(mr_staticCtx, slots);
     }
     RedisModule_FreeClusterNodesList(nodeList);
+
+    // No usable shards from the cluster API -> reject so the caller falls back to long form,
+    // instead of installing an empty topology and replying OK. RED-202230.
+    if (mr_dictSize(clusterCtx.CurrCluster->nodes) == 0) {
+        RedisModule_Log(mr_staticCtx, "warning", "Short-form CLUSTERSET: no valid shards; rejecting");
+        MR_ClusterFree();
+        return REDISMODULE_ERR;
+    }
 
     clusterCtx.clusterSize = mr_dictSize(clusterCtx.CurrCluster->nodes);
     mr_dictEmpty(clusterCtx.nodesMsgIds, NULL);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1107,6 +1107,15 @@ static int SetClusterDataShortForm(RedisModuleString** argv, int argc){
         return REDISMODULE_ERR;
     }
 
+    // GetMyClusterID() is NULL without a cluster identity -> NULL memcpy in SetMyId. Check the
+    // value too, not just the flag: RE's plugin can report cluster mode on before exposing an id.
+    if (!(RedisModule_GetContextFlags(mr_staticCtx) & REDISMODULE_CTX_FLAGS_CLUSTER)
+        || RedisModule_GetMyClusterID() == NULL) {
+        RedisModule_Log(mr_staticCtx, "warning",
+            "Short-form CLUSTERSET rejected: shard has no cluster identity");
+        return REDISMODULE_ERR;
+    }
+
     clusterCtx.CurrCluster = MR_CALLOC(1, sizeof(*clusterCtx.CurrCluster));
     InitClusterData(clusterCtx.CurrCluster, argv, argc);
     memcpy(clusterCtx.myId, clusterCtx.CurrCluster->myId, REDISMODULE_NODE_ID_LEN + 1);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -984,13 +984,16 @@ static void CopyClusterSetArgs(Cluster* cluster, RedisModuleString** argv, int a
     }
 }
 
-static void SetMyId(Cluster* cluster, RedisModuleString** argv, int argc){
-    const char* myId = RedisModule_GetMyClusterID();
+// serverMyId is our id as reported by the server, already checked for NULL by the caller. Only
+// the short form uses it; the long form carries MYID in argv, so it passes NULL.
+static void SetMyId(Cluster* cluster, RedisModuleString** argv, int argc, const char* serverMyId){
+    const char* myId = serverMyId;
     size_t myIdLen = REDISMODULE_NODE_ID_LEN;
     if (IsLongFormClusterSet(argc)) {
         RedisModule_Assert(CLUSTERSET_MYID_LONG_FORM_INDEX < argc);
         myId = RedisModule_StringPtrLen(argv[CLUSTERSET_MYID_LONG_FORM_INDEX], &myIdLen);
     }
+    RedisModule_Assert(myId != NULL);
 
     cluster->myId = MR_ALLOC(REDISMODULE_NODE_ID_LEN + 1);
     size_t zerosPadding = REDISMODULE_NODE_ID_LEN - myIdLen;
@@ -999,14 +1002,14 @@ static void SetMyId(Cluster* cluster, RedisModuleString** argv, int argc){
     cluster->myId[REDISMODULE_NODE_ID_LEN] = '\0';
 }
 
-static void InitClusterData(Cluster* cluster, RedisModuleString** argv, int argc){
+static void InitClusterData(Cluster* cluster, RedisModuleString** argv, int argc, const char* serverMyId){
     cluster->clusterSetCommand = MR_ALLOC(sizeof(char*) * argc);
     cluster->clusterSetCommandSize = argc;
     cluster->clusterSetCommand[0] = MR_STRDUP(CLUSTER_SET_FROM_SHARD_COMMAND);
 
     GenerateRunId(cluster);
     CopyClusterSetArgs(cluster, argv, argc);
-    SetMyId(cluster, argv, argc);
+    SetMyId(cluster, argv, argc, serverMyId);
 
     cluster->nodes = mr_dictCreate(&mr_dictTypeHeapStrings, NULL);
 }
@@ -1104,6 +1107,17 @@ static int ParseShardEntry(RedisModuleString** argv, int argc, int index,
 }
 
 Cluster* MR_BuildCluster(RedisModuleString** argv, int argc, const char* password) {
+    // The short form carries no MYID, so we take our id from the server. Read it once here and
+    // pass it down: it is NULL while the cluster plugin is replacing the topology -- even with
+    // cluster mode reported on -- and re-reading it further down would reopen that window
+    // (MOD-17358). NULL also covers a shard that is not in cluster mode at all.
+    const char* myId = RedisModule_GetMyClusterID();
+    if (!myId) {
+        RedisModule_Log(mr_staticCtx, "warning",
+            "Short-form CLUSTERSET rejected: shard has no cluster identity");
+        return NULL;
+    }
+
     size_t numNodes;
     char **nodeList = RedisModule_GetClusterNodesList(mr_staticCtx, &numNodes);
     if (!nodeList) {
@@ -1112,7 +1126,7 @@ Cluster* MR_BuildCluster(RedisModuleString** argv, int argc, const char* passwor
     }
 
     Cluster* cluster = MR_CALLOC(1, sizeof(*cluster));
-    InitClusterData(cluster, argv, argc);
+    InitClusterData(cluster, argv, argc, myId);
     size_t coveredSlots = 0;
 
     for (size_t i = 0; i < numNodes; i++) {
@@ -1310,17 +1324,6 @@ static int SetClusterDataShortForm(RedisModuleString** argv, int argc){
         return REDISMODULE_ERR;
     }
 
-    // The short form has no MYID of its own, so SetMyId takes it from the server -- and the
-    // server reports none while the cluster plugin is replacing the topology, or when the shard
-    // is not in cluster mode. Check the id and not just the flag: it is missing for a moment on
-    // every topology epoch, with cluster mode reported on throughout (MOD-17358).
-    if (!(RedisModule_GetContextFlags(mr_staticCtx) & REDISMODULE_CTX_FLAGS_CLUSTER)
-        || RedisModule_GetMyClusterID() == NULL) {
-        RedisModule_Log(mr_staticCtx, "warning",
-            "Short-form CLUSTERSET rejected: shard has no cluster identity");
-        return REDISMODULE_ERR;
-    }
-
     const char *password = NULL;
     switch (argc) {
     case 1:
@@ -1362,7 +1365,7 @@ static void SetClusterDataLongForm(RedisModuleString** argv, int argc){
         MR_ClusterFree();
 
     clusterCtx.CurrCluster = MR_CALLOC(1, sizeof(*clusterCtx.CurrCluster));
-    InitClusterData(clusterCtx.CurrCluster, argv, argc);
+    InitClusterData(clusterCtx.CurrCluster, argv, argc, NULL);  // MYID comes from argv
     memcpy(clusterCtx.myId, clusterCtx.CurrCluster->myId, REDISMODULE_NODE_ID_LEN + 1);
 
     size_t index = CLUSTERSET_MYID_LONG_FORM_INDEX + 1;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -984,34 +984,41 @@ static void CopyClusterSetArgs(Cluster* cluster, RedisModuleString** argv, int a
     }
 }
 
-// serverMyId is our id as reported by the server, already checked for NULL by the caller. Only
-// the short form uses it; the long form carries MYID in argv, so it passes NULL.
-static void SetMyId(Cluster* cluster, RedisModuleString** argv, int argc, const char* serverMyId){
-    const char* myId = serverMyId;
+static int SetMyId(Cluster* cluster, RedisModuleString** argv, int argc){
+    const char* myId = RedisModule_GetMyClusterID();
     size_t myIdLen = REDISMODULE_NODE_ID_LEN;
     if (IsLongFormClusterSet(argc)) {
         RedisModule_Assert(CLUSTERSET_MYID_LONG_FORM_INDEX < argc);
         myId = RedisModule_StringPtrLen(argv[CLUSTERSET_MYID_LONG_FORM_INDEX], &myIdLen);
+    } else if (!myId) {
+        // The short form has no MYID of its own, and the server reports none while the cluster
+        // plugin is replacing the topology -- with cluster mode still reported on (MOD-17358).
+        RedisModule_Log(mr_staticCtx, "warning",
+            "Short-form CLUSTERSET rejected: shard has no cluster identity");
+        return REDISMODULE_ERR;
     }
-    RedisModule_Assert(myId != NULL);
 
     cluster->myId = MR_ALLOC(REDISMODULE_NODE_ID_LEN + 1);
     size_t zerosPadding = REDISMODULE_NODE_ID_LEN - myIdLen;
     memset(cluster->myId, '0', zerosPadding);
     memcpy(cluster->myId + zerosPadding, myId, myIdLen);
     cluster->myId[REDISMODULE_NODE_ID_LEN] = '\0';
+    return REDISMODULE_OK;
 }
 
-static void InitClusterData(Cluster* cluster, RedisModuleString** argv, int argc, const char* serverMyId){
+static int InitClusterData(Cluster* cluster, RedisModuleString** argv, int argc){
     cluster->clusterSetCommand = MR_ALLOC(sizeof(char*) * argc);
     cluster->clusterSetCommandSize = argc;
     cluster->clusterSetCommand[0] = MR_STRDUP(CLUSTER_SET_FROM_SHARD_COMMAND);
 
     GenerateRunId(cluster);
     CopyClusterSetArgs(cluster, argv, argc);
-    SetMyId(cluster, argv, argc, serverMyId);
+    if (SetMyId(cluster, argv, argc) != REDISMODULE_OK) {
+        return REDISMODULE_ERR;
+    }
 
     cluster->nodes = mr_dictCreate(&mr_dictTypeHeapStrings, NULL);
+    return REDISMODULE_OK;
 }
 
 #define INTERNAL_PASSWORD_MAX_SIZE 100
@@ -1107,17 +1114,6 @@ static int ParseShardEntry(RedisModuleString** argv, int argc, int index,
 }
 
 Cluster* MR_BuildCluster(RedisModuleString** argv, int argc, const char* password) {
-    // The short form carries no MYID, so we take our id from the server. Read it once here and
-    // pass it down: it is NULL while the cluster plugin is replacing the topology -- even with
-    // cluster mode reported on -- and re-reading it further down would reopen that window
-    // (MOD-17358). NULL also covers a shard that is not in cluster mode at all.
-    const char* myId = RedisModule_GetMyClusterID();
-    if (!myId) {
-        RedisModule_Log(mr_staticCtx, "warning",
-            "Short-form CLUSTERSET rejected: shard has no cluster identity");
-        return NULL;
-    }
-
     size_t numNodes;
     char **nodeList = RedisModule_GetClusterNodesList(mr_staticCtx, &numNodes);
     if (!nodeList) {
@@ -1126,7 +1122,11 @@ Cluster* MR_BuildCluster(RedisModuleString** argv, int argc, const char* passwor
     }
 
     Cluster* cluster = MR_CALLOC(1, sizeof(*cluster));
-    InitClusterData(cluster, argv, argc, myId);
+    if (InitClusterData(cluster, argv, argc) != REDISMODULE_OK) {
+        FreeCluster(cluster);
+        RedisModule_FreeClusterNodesList(nodeList);
+        return NULL;
+    }
     size_t coveredSlots = 0;
 
     for (size_t i = 0; i < numNodes; i++) {
@@ -1365,7 +1365,8 @@ static void SetClusterDataLongForm(RedisModuleString** argv, int argc){
         MR_ClusterFree();
 
     clusterCtx.CurrCluster = MR_CALLOC(1, sizeof(*clusterCtx.CurrCluster));
-    InitClusterData(clusterCtx.CurrCluster, argv, argc, NULL);  // MYID comes from argv
+    int initRes = InitClusterData(clusterCtx.CurrCluster, argv, argc);
+    RedisModule_Assert(initRes == REDISMODULE_OK);  // long form carries MYID in argv
     memcpy(clusterCtx.myId, clusterCtx.CurrCluster->myId, REDISMODULE_NODE_ID_LEN + 1);
 
     size_t index = CLUSTERSET_MYID_LONG_FORM_INDEX + 1;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -991,8 +991,9 @@ static int SetMyId(Cluster* cluster, RedisModuleString** argv, int argc){
         RedisModule_Assert(CLUSTERSET_MYID_LONG_FORM_INDEX < argc);
         myId = RedisModule_StringPtrLen(argv[CLUSTERSET_MYID_LONG_FORM_INDEX], &myIdLen);
     } else if (!myId) {
-        // The short form has no MYID of its own, and the server reports none while the cluster
-        // plugin is replacing the topology -- with cluster mode still reported on (MOD-17358).
+        // The short form has no MYID of its own, and the server reports none on a shard with no
+        // cluster identity -- also while the cluster plugin is replacing the topology, with
+        // cluster mode still reported on (MOD-17358).
         RedisModule_Log(mr_staticCtx, "warning",
             "Short-form CLUSTERSET rejected: shard has no cluster identity");
         return REDISMODULE_ERR;
@@ -1134,24 +1135,18 @@ Cluster* MR_BuildCluster(RedisModuleString** argv, int argc, const char* passwor
         memcpy(nodeId, nodeList[i], REDISMODULE_NODE_ID_LEN);
         nodeId[REDISMODULE_NODE_ID_LEN] = '\0';
 
-        char ip[INET6_ADDRSTRLEN] = {0};  // INET6_ADDRSTRLEN includes the closing '\0'
-        int port = 0, flags = 0;
+        char ip[INET6_ADDRSTRLEN];  // INET6_ADDRSTRLEN includes the closing '\0'
+        int port, flags;
 
-        // Skip nodes with no usable endpoint, e.g. Redis Enterprise without the node-port
-        // backport, where getNodeDefaultClientPort() gives 0 (RED-202230).
-        if (RedisModule_GetClusterNodeInfo(mr_staticCtx, nodeId, ip, NULL, &port, &flags) != REDISMODULE_OK
-            || port <= 0 || ip[0] == '\0') {
-            RedisModule_Log(mr_staticCtx, "warning", "Short-form CLUSTERSET: no valid endpoint for node %s", nodeId);
+        if (RedisModule_GetClusterNodeInfo(mr_staticCtx, nodeId, ip, NULL, &port, &flags) != REDISMODULE_OK) {
+            RedisModule_Log(mr_staticCtx, "warning", "Failed to get info for node %s", nodeId);
             continue;
         }
 
         if (!(flags & REDISMODULE_NODE_MASTER)) continue;  // Skip replica nodes
 
         RedisModuleSlotRangeArray *slots = RedisModule_GetClusterNodeSlotRanges(mr_staticCtx, nodeId);
-        if (slots == NULL) {  // incomplete topology; skip instead of asserting
-            RedisModule_Log(mr_staticCtx, "warning", "Short-form CLUSTERSET: no slot ranges for node %s; skipping", nodeId);
-            continue;
-        }
+        RedisModule_Assert(slots != NULL);
         long long minSlot = 0, maxSlot = -1;  // min > max indicates a no-hslots range (i.e., used for slotless shards)
         if (slots->num_ranges > 0) {
             minSlot = slots->ranges[0].start;


### PR DESCRIPTION
## What

`SetMyId()` reports failure when the shard has no cluster identity, instead of copying from a NULL pointer. 21 insertions, 5 deletions.

## Why

`timeseries.CLUSTERSET`'s short form carries no `MYID`, so LibMR takes this shard's id from the server:

```c
const char* myId = RedisModule_GetMyClusterID();
...
memcpy(cluster->myId + zerosPadding, myId, myIdLen);   // myId == NULL -> SIGSEGV
```

`RedisModule_GetMyClusterID()` is documented nullable, and the command is deliberately registered **without** the `internal` flag (unlike `CLUSTERSETFROMSHARD` and `HELLO`) so RAMP can see it in `COMMAND LIST`. The result is that on a shard with no cluster identity, any client can kill the server with one command:

```
redis-server --cluster-enabled no --loadmodule redistimeseries.so
TIMESERIES.CLUSTERSET      # -> SIGSEGV on the timeseries-el thread
```

That is the whole case for this PR now. It reproduces on a plain standalone shard with no Enterprise involvement, so it is fixed here regardless of what the platform does or does not send.

The id can also be NULL transiently *in* cluster mode, because Enterprise's cluster plugin clears `myself` on every topology apply — that is MOD-17358, and the root cause is fixed in redislabsdev/clusterlib#16. This guard is not the fix for it; once clusterlib#16 ships, this path stops being reachable on Enterprise. It still covers standalone shards and any build that predates it.

## Scope

Narrowed from what this branch originally proposed. The RED-202230 guards (skip `port <= 0` / empty ip, soft-skip NULL slot ranges) are gone — those conditions no longer exist:

- port: fixed in the Redis fork by "Fix getNodeDefaultClientPort call with cluster_plugin (#1468)", 25 Jun 2026, on `rl_8.4` `e25184b9f`, `rl_8.6` `823878e0d`, `rl_8.8` `905417650`, and `rl_unstable`. RED-202230 is closed Won't Do because it was solved there rather than in the plugin.
- slot ranges: `RM_GetClusterNodeSlotRanges` returns `slotRangeArrayCreate(0)`, never NULL.
- ip: `RM_GetClusterNodeInfo` `redis_strlcpy`s it on every `REDISMODULE_OK` path.

Keeping them would also have been actively risky: on a build still carrying the old port stub, skipping every `port <= 0` node would have made `MR_BuildCluster` reject every short-form CLUSTERSET on Enterprise, disabling the feature as a side effect of a crash fix.

## Shape

The check is where the value is used. `SetMyId()` already loads the id into a local, so checking it there means there is no second read to race with. `MR_BuildCluster` and `SetClusterDataShortForm` already return `NULL` / `REDISMODULE_ERR`, so this feeds paths that exist rather than adding new ones, and `FreeCluster()` is NULL-tolerant, so the cleanup is two lines. The long form is unaffected: it carries `MYID` in argv, so its `InitClusterData()` call asserts rather than branching.

Rejecting is what lets the caller recover: DMC's `send_cluster_info_with_short_fallback` already retries with the long form on an error reply. In the MOD-17358 crash it fired 13 ms after the send and found the shard dead.

## Verification

RTS 8.8.2 (LibMR pin `a37b672`) built for linux-arm64 in `rockylinux:9` + `gcc-toolset-13`, against a redis that exports `GetClusterNodeSlotRanges`, standalone shard, bare `TIMESERIES.CLUSTERSET`:

| | before | after |
|---|---|---|
| reply | connection closed | `ERRCLUSTER Failed to set cluster topology` |
| shard | SIGSEGV `(nil)`, thread `timeseries-el` | alive (`PONG`) |
| crash reports | 2 | 0 |

The reproduced stack matches the three field crashes frame for frame, including `event_base_loop+0x2ac`. A TS-side flow test rides with the module re-pin.
