### PR TITLE
MOD-16382 Handle topology-change notifications

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -785,33 +785,37 @@ static void MR_NodeFree(Node* n){
     MR_NodeFreeInternals(n);
 }
 
-static void MR_ClusterFree(){
-    MR_AbortRunningExecutions();
-
-    if(clusterCtx.CurrCluster->myId){
-        MR_FREE(clusterCtx.CurrCluster->myId);
+static void FreeCluster(Cluster* cluster){
+    if(cluster->myId){
+        MR_FREE(cluster->myId);
     }
-    if(clusterCtx.CurrCluster->nodes){
-        mr_dictIterator *iter = mr_dictGetIterator(clusterCtx.CurrCluster->nodes);
+    if(cluster->nodes){
+        mr_dictIterator *iter = mr_dictGetIterator(cluster->nodes);
         mr_dictEntry *entry = NULL;
         while((entry = mr_dictNext(iter))){
             Node* n = mr_dictGetVal(entry);
             MR_NodeFree(n);
         }
         mr_dictReleaseIterator(iter);
-        mr_dictRelease(clusterCtx.CurrCluster->nodes);
+        mr_dictRelease(cluster->nodes);
     }
 
-    if(clusterCtx.CurrCluster->clusterSetCommand){
-        for(int i = 0 ; i < clusterCtx.CurrCluster->clusterSetCommandSize ; ++i){
-            if(clusterCtx.CurrCluster->clusterSetCommand[i]){
-                MR_FREE(clusterCtx.CurrCluster->clusterSetCommand[i]);
+    if(cluster->clusterSetCommand){
+        for(int i = 0 ; i < cluster->clusterSetCommandSize ; ++i){
+            if(cluster->clusterSetCommand[i]){
+                MR_FREE(cluster->clusterSetCommand[i]);
             }
         }
-        MR_FREE(clusterCtx.CurrCluster->clusterSetCommand);
+        MR_FREE(cluster->clusterSetCommand);
     }
 
-    MR_FREE(clusterCtx.CurrCluster);
+    MR_FREE(cluster);
+}
+
+static void MR_ClusterFree(){
+    MR_AbortRunningExecutions();
+
+    FreeCluster(clusterCtx.CurrCluster);
     clusterCtx.CurrCluster = NULL;
     clusterCtx.minSlot = 0;
     clusterCtx.maxSlot = 0;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -145,7 +145,7 @@ typedef struct Node{
 
 typedef struct Cluster {
     char* myId;
-    mr_dict* nodes;  // Note: we only keep master nodes here
+    mr_dict* nodes;  // Note: we only keep master nodes here (including slotless master nodes, if any)
     Node* slots[NUMBER_OF_SLOTS];
     size_t clusterSetCommandSize;
     char** clusterSetCommand;
@@ -1141,11 +1141,24 @@ Cluster* BuildCluster(RedisModuleString** argv, int argc, const char* password) 
             maxSlot = slots->ranges[j].end;
             if (j > 0)  // The 0 case is handled by the MR_CreateNode() above
                 mr_listAddNodeTail(aMasterNode->slotRanges, NewSlotRange(minSlot, maxSlot));
-            for (int k = minSlot ; k <= maxSlot ; k++)
+            for (int k = minSlot ; k <= maxSlot ; k++) {
+                if (cluster->slots[k] != NULL) {
+                    RedisModule_Log(mr_staticCtx, "warning",
+                        "Slot %d is claimed by two master nodes: %s and %s; rejecting topology",
+                        k, cluster->slots[k]->id, aMasterNode->id);
+                    FreeCluster(cluster);
+                    cluster = NULL;
+                    break;
+                }
                 cluster->slots[k] = aMasterNode;
+            }
+            if (cluster == NULL)
+                break;
         }
 
         RedisModule_ClusterFreeSlotRanges(mr_staticCtx, slots);
+        if (cluster == NULL)
+            break;
     }
     RedisModule_FreeClusterNodesList(nodeList);
 
@@ -1157,6 +1170,7 @@ Cluster* BuildCluster(RedisModuleString** argv, int argc, const char* password) 
 // there, or scheduled as a task from MR_UpdateClusterTopology on the main thread).
 void MR_UpdateClusterTopologyInternal(void* ctx){
     Cluster* cluster = ctx;
+    RedisModule_Assert(cluster != NULL);
 
     clusterCtx.CurrCluster = cluster;
     memcpy(clusterCtx.myId, cluster->myId, REDISMODULE_NODE_ID_LEN + 1);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -938,7 +938,7 @@ static void MR_RefreshClusterData(){
         Node* n = MR_GetNode(clusterCtx.CurrCluster, nodeId);
         if(!n){
             /* If we have internal secret we will ignore the clusterCtx.password, we do not need it. */
-            n = MR_CreateNode(clusterCtx.CurrCluster, nodeId, nodeIp, (unsigned short)port, RedisModule_GetInternalSecret ? NULL : clusterCtx.password, NULL, minSlot, maxSlot);
+            n = MR_CreateNode(clusterCtx.CurrCluster, nodeId, nodeIp, (unsigned short)port, MR_ClusterGetPassword(), NULL, minSlot, maxSlot);
         }
 
         if (n->isMe) {
@@ -1168,7 +1168,7 @@ static int SetClusterDataShortForm(RedisModuleString** argv, int argc){
     const char *password = NULL;
     switch (argc) {
     case 1:
-        password = NULL;
+        password = MR_ClusterGetPassword();
         break;
     case 3: {
         const char *token = RedisModule_StringPtrLen(argv[1], NULL);
@@ -1835,3 +1835,6 @@ const char* MR_ClusterGetMyId(){
     return clusterCtx.myId;
 }
 
+const char *MR_ClusterGetPassword(){
+    return RedisModule_GetInternalSecret ? NULL : clusterCtx.password;
+}

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -196,7 +196,7 @@ static void MR_OnStatusResponseArrived(struct redisAsyncContext* c, void* a, voi
 static void MR_OnDataResponseArrived(struct redisAsyncContext* c, void* a, void* b);  // A response to an internal-commands command
 static void MR_ConnectToShard(Node* n);
 static void MR_HelloResponseArrived(struct redisAsyncContext* c, void* a, void* b);
-static Node* MR_GetNode(const char* id);
+static Node* MR_GetNode(Cluster* cluster, const char* id);
 
 static SlotRange* NewSlotRange(uint16_t minSlot, uint16_t maxSlot) {
     SlotRange* result = MR_ALLOC(sizeof(*result));
@@ -263,7 +263,7 @@ static void MR_ClusterSendMsgTask(void* ctx) {
         return;
     }
     if (sendMsg->sendMsgType == SendMsgType_ById) {
-        Node* n = MR_GetNode(sendMsg->idToSend);
+        Node* n = MR_GetNode(clusterCtx.CurrCluster, sendMsg->idToSend);
         if(!n){
             RedisModule_Log(mr_staticCtx, "warning", "Could not find node to send message to");
         } else {
@@ -819,8 +819,8 @@ static void MR_ClusterFree(){
     memset(clusterCtx.myId, '0', REDISMODULE_NODE_ID_LEN);
 }
 
-static Node* MR_GetNode(const char* id){
-    mr_dictEntry *entry = mr_dictFind(clusterCtx.CurrCluster->nodes, id);
+static Node* MR_GetNode(Cluster* cluster, const char* id){
+    mr_dictEntry *entry = mr_dictFind(cluster->nodes, id);
     Node* n = NULL;
     if(entry){
         n = mr_dictGetVal(entry);
@@ -828,8 +828,8 @@ static Node* MR_GetNode(const char* id){
     return n;
 }
 
-static Node* MR_CreateNode(const char* id, const char* ip, unsigned short port, const char* password, const char* unixSocket, long long minSlot, long long maxSlot){
-    RedisModule_Assert(!MR_GetNode(id));
+static Node* MR_CreateNode(Cluster* cluster, const char* id, const char* ip, unsigned short port, const char* password, const char* unixSocket, long long minSlot, long long maxSlot){
+    RedisModule_Assert(!MR_GetNode(cluster, id));
 
     mr_list* slotRanges = mr_listCreate();
     mr_listSetFreeMethod(slotRanges, FreeSlotRange);
@@ -859,9 +859,9 @@ static Node* MR_CreateNode(const char* id, const char* ip, unsigned short port, 
             .reconnectEvent = NULL,
             .resendHelloEvent = NULL,
     };
-    n->index = mr_dictSize(clusterCtx.CurrCluster->nodes);
-    n->isMe = strcmp(id, clusterCtx.CurrCluster->myId) == 0;
-    mr_dictAdd(clusterCtx.CurrCluster->nodes, n->id, n);
+    n->index = mr_dictSize(cluster->nodes);
+    n->isMe = strcmp(id, cluster->myId) == 0;
+    mr_dictAdd(cluster->nodes, n->id, n);
 
     return n;
 }
@@ -935,10 +935,10 @@ static void MR_RefreshClusterData(){
         RedisModule_ThreadSafeContextUnlock(mr_staticCtx);
 
 
-        Node* n = MR_GetNode(nodeId);
+        Node* n = MR_GetNode(clusterCtx.CurrCluster, nodeId);
         if(!n){
             /* If we have internal secret we will ignore the clusterCtx.password, we do not need it. */
-            n = MR_CreateNode(nodeId, nodeIp, (unsigned short)port, RedisModule_GetInternalSecret ? NULL : clusterCtx.password, NULL, minSlot, maxSlot);
+            n = MR_CreateNode(clusterCtx.CurrCluster, nodeId, nodeIp, (unsigned short)port, RedisModule_GetInternalSecret ? NULL : clusterCtx.password, NULL, minSlot, maxSlot);
         }
 
         if (n->isMe) {
@@ -1090,48 +1090,16 @@ static int ParseShardEntry(RedisModuleString** argv, int argc, int index,
     return index;
 }
 
-static int SetClusterDataShortForm(RedisModuleString** argv, int argc){
-    RedisModule_Log(mr_staticCtx, "notice", "Got cluster set command (short form)");
-
-    // RedisModule_GetClusterNodeSlotRanges may be NULL when the host Redis
-    // build does not export it (e.g. OSS Redis without the backport). Reject
-    // the command with an error instead of crashing or silently no-op'ing, so
-    // the caller (e.g. DMC) can fall back to the long-form CLUSTERSET. The
-    // cluster stays unconfigured until a long-form CLUSTERSET or REFRESHCLUSTER
-    // arrives.
-    if (RedisModule_GetClusterNodeSlotRanges == NULL) {
-        RedisModule_Log(mr_staticCtx, "warning",
-            "Short-form CLUSTERSET received, but RedisModule_GetClusterNodeSlotRanges "
-            "is not available in this Redis build. Use long-form CLUSTERSET or "
-            "REFRESHCLUSTER to configure the cluster.");
-        return REDISMODULE_ERR;
-    }
-
-    clusterCtx.CurrCluster = MR_CALLOC(1, sizeof(*clusterCtx.CurrCluster));
-    InitClusterData(clusterCtx.CurrCluster, argv, argc);
-    memcpy(clusterCtx.myId, clusterCtx.CurrCluster->myId, REDISMODULE_NODE_ID_LEN + 1);
-
-    const char *password = NULL;
-    switch (argc) {
-    case 1:
-        password = NULL;
-        break;
-    case 3: {
-        const char *token = RedisModule_StringPtrLen(argv[1], NULL);
-        RedisModule_Assert(strcasecmp(token, "AUTH") == 0);
-        password = RedisModule_StringPtrLen(argv[2], NULL);
-        break;
-    }
-    default:
-        RedisModule_Assert(0);
-    }
-
+static Cluster* BuildCluster(RedisModuleString** argv, int argc, const char* password){
     size_t numNodes;
     char **nodeList = RedisModule_GetClusterNodesList(mr_staticCtx, &numNodes);
     if (!nodeList) {
         RedisModule_Log(mr_staticCtx, "warning", "Failed to get cluster nodes list");
-        return REDISMODULE_ERR;
+        return NULL;
     }
+
+    Cluster* cluster = MR_CALLOC(1, sizeof(*cluster));
+    InitClusterData(cluster, argv, argc);
 
     for (size_t i = 0; i < numNodes; i++) {
         char nodeId[REDISMODULE_NODE_ID_LEN + 1];  // nodeList[i] is not null-terminated
@@ -1156,18 +1124,13 @@ static int SetClusterDataShortForm(RedisModuleString** argv, int argc){
             maxSlot = slots->ranges[0].end;
         }
 
-        Node* aMasterNode = MR_CreateNode(nodeId, ip, port, password, NULL, minSlot, maxSlot);
+        Node* aMasterNode = MR_CreateNode(cluster, nodeId, ip, port, password, NULL, minSlot, maxSlot);
         // Note that MR_CreateNode has already set the isMe bool, but since here we have the flags
         // which are the "formal" way to know if this node is me, we override it here.
         // Basically they should have the same outcome, but given the various ways we name a node
         // (e.g., in RE they are the shard uids, left-padded with 0s), it's safer not to assert
         // that they are the same and use the flags as the actual true value.
         aMasterNode->isMe = (flags & REDISMODULE_NODE_MYSELF) != 0;
-        if (aMasterNode->isMe) {
-            // fill the fallback single-range; see the comment at the declaration of minSlot and maxSlot
-            clusterCtx.minSlot = minSlot;
-            clusterCtx.maxSlot = maxSlot;
-        }
 
         for (size_t j = 0; j < slots->num_ranges; j++) {
             minSlot = slots->ranges[j].start;
@@ -1175,12 +1138,72 @@ static int SetClusterDataShortForm(RedisModuleString** argv, int argc){
             if (j > 0)  // The 0 case is handled by the MR_CreateNode() above
                 mr_listAddNodeTail(aMasterNode->slotRanges, NewSlotRange(minSlot, maxSlot));
             for (int k = minSlot ; k <= maxSlot ; k++)
-                clusterCtx.CurrCluster->slots[k] = aMasterNode;
+                cluster->slots[k] = aMasterNode;
         }
 
         RedisModule_ClusterFreeSlotRanges(mr_staticCtx, slots);
     }
     RedisModule_FreeClusterNodesList(nodeList);
+
+    return cluster;
+}
+
+static int SetClusterDataShortForm(RedisModuleString** argv, int argc){
+    RedisModule_Log(mr_staticCtx, "notice", "Got cluster set command (short form)");
+
+    // RedisModule_GetClusterNodeSlotRanges may be NULL when the host Redis
+    // build does not export it (e.g. OSS Redis without the backport). Reject
+    // the command with an error instead of crashing or silently no-op'ing, so
+    // the caller (e.g. DMC) can fall back to the long-form CLUSTERSET. The
+    // cluster stays unconfigured until a long-form CLUSTERSET or REFRESHCLUSTER
+    // arrives.
+    if (RedisModule_GetClusterNodeSlotRanges == NULL) {
+        RedisModule_Log(mr_staticCtx, "warning",
+            "Short-form CLUSTERSET received, but RedisModule_GetClusterNodeSlotRanges "
+            "is not available in this Redis build. Use long-form CLUSTERSET or "
+            "REFRESHCLUSTER to configure the cluster.");
+        return REDISMODULE_ERR;
+    }
+
+    const char *password = NULL;
+    switch (argc) {
+    case 1:
+        password = NULL;
+        break;
+    case 3: {
+        const char *token = RedisModule_StringPtrLen(argv[1], NULL);
+        RedisModule_Assert(strcasecmp(token, "AUTH") == 0);
+        password = RedisModule_StringPtrLen(argv[2], NULL);
+        break;
+    }
+    default:
+        RedisModule_Assert(0);
+    }
+
+    clusterCtx.CurrCluster = BuildCluster(argv, argc, password);
+    if (!clusterCtx.CurrCluster) {
+        return REDISMODULE_ERR;
+    }
+    memcpy(clusterCtx.myId, clusterCtx.CurrCluster->myId, REDISMODULE_NODE_ID_LEN + 1);
+
+    // Calculate the min/max slots for clusterCtx (legacy, fallback single-range; see the comment at the struct declaration)
+    long long minSlot = 0, maxSlot = -1;  // min > max indicates a no-hslots range (i.e., used for slotless shards)
+    mr_dictIterator *iter = mr_dictGetIterator(clusterCtx.CurrCluster->nodes);
+    mr_dictEntry *entry = NULL;
+    while ((entry = mr_dictNext(iter)) != NULL) {
+        Node* n = mr_dictGetVal(entry);
+        if (!n->isMe)
+            continue;
+        if (mr_listLength(n->slotRanges) > 0) {
+            SlotRange* r = mr_listNodeValue(mr_listFirst(n->slotRanges));
+            minSlot = r->minSlot;
+            maxSlot = r->maxSlot;
+        }
+        break;
+    }
+    mr_dictReleaseIterator(iter);
+    clusterCtx.minSlot = minSlot;
+    clusterCtx.maxSlot = maxSlot;
 
     clusterCtx.clusterSize = mr_dictSize(clusterCtx.CurrCluster->nodes);
     mr_dictEmpty(clusterCtx.nodesMsgIds, NULL);
@@ -1228,9 +1251,9 @@ static void SetClusterDataLongForm(RedisModuleString** argv, int argc){
             continue;
 
         // Create a new node or update an existing one
-        Node* aMasterNode = MR_GetNode(realId);
+        Node* aMasterNode = MR_GetNode(clusterCtx.CurrCluster, realId);
         if(!aMasterNode){
-            aMasterNode = MR_CreateNode(realId, ip, port, password, NULL, minSlot, maxSlot);
+            aMasterNode = MR_CreateNode(clusterCtx.CurrCluster, realId, ip, port, password, NULL, minSlot, maxSlot);
         } else {
             RedisModule_Assert(minSlot <= maxSlot);  // slotless nodes are only created (above)
             mr_listAddNodeTail(aMasterNode->slotRanges, NewSlotRange(minSlot, maxSlot));

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1177,13 +1177,56 @@ Cluster* BuildCluster(RedisModuleString** argv, int argc, const char* password) 
     return cluster;
 }
 
-// Installs an already-built cluster into the cluster context. Runs on the event
-// loop thread (either directly from the short-form CLUSTERSET, which already runs
-// there, or scheduled as a task from MR_UpdateClusterTopology on the main thread).
-void MR_UpdateClusterTopologyInternal(void* ctx){
+static bool SameNode(Node* a, Node* b) {
+    return strcmp(a->id, b->id) == 0 && strcmp(a->ip, b->ip) == 0 && a->port == b->port;
+}
+
+static bool SameSlotRanges(Node* a, Node* b) {
+    if (mr_listLength(a->slotRanges) != mr_listLength(b->slotRanges))
+        return false;
+    mr_listNode* ia = mr_listFirst(a->slotRanges);
+    mr_listNode* ib = mr_listFirst(b->slotRanges);
+    while (ia != NULL) {
+        SlotRange* ra = mr_listNodeValue(ia);
+        SlotRange* rb = mr_listNodeValue(ib);
+        if (ra->minSlot != rb->minSlot || ra->maxSlot != rb->maxSlot)
+            return false;
+        ia = mr_listNextNode(ia);
+        ib = mr_listNextNode(ib);
+    }
+    return true;
+}
+
+static bool SameCluster(Cluster* a, Cluster* b) {
+    if (a == b)
+        return true;
+    if (a == NULL || b == NULL)
+        return false;
+    if (mr_dictSize(a->nodes) != mr_dictSize(b->nodes))
+        return false;
+    mr_dictIterator* iter = mr_dictGetIterator(a->nodes);
+    mr_dictEntry* entry = NULL;
+    while ((entry = mr_dictNext(iter)) != NULL) {
+        Node* na = mr_dictGetVal(entry);
+        Node* nb = MR_GetNode(b, na->id);
+        if (nb == NULL || !SameNode(na, nb) || !SameSlotRanges(na, nb))
+            break;
+    }
+    mr_dictReleaseIterator(iter);
+    return entry == NULL;
+}
+
+void MR_UpdateClusterTopologyIfNeeded(void* ctx){
     Cluster* cluster = ctx;
     RedisModule_Assert(cluster != NULL);
 
+    if (SameCluster(cluster, clusterCtx.CurrCluster)) {
+        FreeCluster(cluster);
+        return;
+    }
+
+    if (clusterCtx.CurrCluster)
+        MR_ClusterFree();
     clusterCtx.CurrCluster = cluster;
     memcpy(clusterCtx.myId, cluster->myId, REDISMODULE_NODE_ID_LEN + 1);
 
@@ -1246,7 +1289,7 @@ static int SetClusterDataShortForm(RedisModuleString** argv, int argc){
     if (!cluster)
         return REDISMODULE_ERR;
 
-    MR_UpdateClusterTopologyInternal(cluster);
+    MR_UpdateClusterTopologyIfNeeded(cluster);
     return REDISMODULE_OK;
 }
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -786,9 +786,11 @@ static void MR_NodeFree(Node* n){
 }
 
 static void FreeCluster(Cluster* cluster){
-    if(cluster->myId){
+    if(!cluster)
+        return;
+
+    if(cluster->myId)
         MR_FREE(cluster->myId);
-    }
     if(cluster->nodes){
         mr_dictIterator *iter = mr_dictGetIterator(cluster->nodes);
         mr_dictEntry *entry = NULL;
@@ -1104,6 +1106,7 @@ Cluster* BuildCluster(RedisModuleString** argv, int argc, const char* password) 
 
     Cluster* cluster = MR_CALLOC(1, sizeof(*cluster));
     InitClusterData(cluster, argv, argc);
+    size_t coveredSlots = 0;
 
     for (size_t i = 0; i < numNodes; i++) {
         char nodeId[REDISMODULE_NODE_ID_LEN + 1];  // nodeList[i] is not null-terminated
@@ -1139,6 +1142,7 @@ Cluster* BuildCluster(RedisModuleString** argv, int argc, const char* password) 
         for (size_t j = 0; j < slots->num_ranges; j++) {
             minSlot = slots->ranges[j].start;
             maxSlot = slots->ranges[j].end;
+            coveredSlots += (maxSlot - minSlot + 1);
             if (j > 0)  // The 0 case is handled by the MR_CreateNode() above
                 mr_listAddNodeTail(aMasterNode->slotRanges, NewSlotRange(minSlot, maxSlot));
             for (int k = minSlot ; k <= maxSlot ; k++) {
@@ -1161,6 +1165,14 @@ Cluster* BuildCluster(RedisModuleString** argv, int argc, const char* password) 
             break;
     }
     RedisModule_FreeClusterNodesList(nodeList);
+
+    if (cluster != NULL && coveredSlots != NUMBER_OF_SLOTS) {
+        RedisModule_Log(mr_staticCtx, "warning",
+            "Cluster topology covers %zu of %d slots; rejecting topology",
+            coveredSlots, NUMBER_OF_SLOTS);
+        FreeCluster(cluster);
+        cluster = NULL;
+    }
 
     return cluster;
 }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -145,7 +145,7 @@ typedef struct Node{
 
 typedef struct Cluster {
     char* myId;
-    mr_dict* nodes;
+    mr_dict* nodes;  // Note: we only keep master nodes here
     Node* slots[NUMBER_OF_SLOTS];
     size_t clusterSetCommandSize;
     char** clusterSetCommand;
@@ -1094,7 +1094,7 @@ static int ParseShardEntry(RedisModuleString** argv, int argc, int index,
     return index;
 }
 
-static Cluster* BuildCluster(RedisModuleString** argv, int argc, const char* password){
+Cluster* BuildCluster(RedisModuleString** argv, int argc, const char* password) {
     size_t numNodes;
     char **nodeList = RedisModule_GetClusterNodesList(mr_staticCtx, &numNodes);
     if (!nodeList) {

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1152,6 +1152,38 @@ static Cluster* BuildCluster(RedisModuleString** argv, int argc, const char* pas
     return cluster;
 }
 
+// Installs an already-built cluster into the cluster context. Runs on the event
+// loop thread (either directly from the short-form CLUSTERSET, which already runs
+// there, or scheduled as a task from MR_UpdateClusterTopology on the main thread).
+void MR_UpdateClusterTopologyInternal(void* ctx){
+    Cluster* cluster = ctx;
+
+    clusterCtx.CurrCluster = cluster;
+    memcpy(clusterCtx.myId, cluster->myId, REDISMODULE_NODE_ID_LEN + 1);
+
+    // Calculate the min/max slots for clusterCtx (legacy, fallback single-range; see the comment at the struct declaration)
+    long long minSlot = 0, maxSlot = -1;  // min > max indicates a no-hslots range (i.e., used for slotless shards)
+    mr_dictIterator *iter = mr_dictGetIterator(cluster->nodes);
+    mr_dictEntry *entry = NULL;
+    while ((entry = mr_dictNext(iter)) != NULL) {
+        Node* n = mr_dictGetVal(entry);
+        if (!n->isMe)
+            continue;
+        if (mr_listLength(n->slotRanges) > 0) {
+            SlotRange* r = mr_listNodeValue(mr_listFirst(n->slotRanges));
+            minSlot = r->minSlot;
+            maxSlot = r->maxSlot;
+        }
+        break;
+    }
+    mr_dictReleaseIterator(iter);
+    clusterCtx.minSlot = minSlot;
+    clusterCtx.maxSlot = maxSlot;
+
+    clusterCtx.clusterSize = mr_dictSize(cluster->nodes);
+    mr_dictEmpty(clusterCtx.nodesMsgIds, NULL);
+}
+
 static int SetClusterDataShortForm(RedisModuleString** argv, int argc){
     RedisModule_Log(mr_staticCtx, "notice", "Got cluster set command (short form)");
 
@@ -1184,33 +1216,11 @@ static int SetClusterDataShortForm(RedisModuleString** argv, int argc){
         RedisModule_Assert(0);
     }
 
-    clusterCtx.CurrCluster = BuildCluster(argv, argc, password);
-    if (!clusterCtx.CurrCluster) {
+    Cluster* cluster = BuildCluster(argv, argc, password);
+    if (!cluster)
         return REDISMODULE_ERR;
-    }
-    memcpy(clusterCtx.myId, clusterCtx.CurrCluster->myId, REDISMODULE_NODE_ID_LEN + 1);
 
-    // Calculate the min/max slots for clusterCtx (legacy, fallback single-range; see the comment at the struct declaration)
-    long long minSlot = 0, maxSlot = -1;  // min > max indicates a no-hslots range (i.e., used for slotless shards)
-    mr_dictIterator *iter = mr_dictGetIterator(clusterCtx.CurrCluster->nodes);
-    mr_dictEntry *entry = NULL;
-    while ((entry = mr_dictNext(iter)) != NULL) {
-        Node* n = mr_dictGetVal(entry);
-        if (!n->isMe)
-            continue;
-        if (mr_listLength(n->slotRanges) > 0) {
-            SlotRange* r = mr_listNodeValue(mr_listFirst(n->slotRanges));
-            minSlot = r->minSlot;
-            maxSlot = r->maxSlot;
-        }
-        break;
-    }
-    mr_dictReleaseIterator(iter);
-    clusterCtx.minSlot = minSlot;
-    clusterCtx.maxSlot = maxSlot;
-
-    clusterCtx.clusterSize = mr_dictSize(clusterCtx.CurrCluster->nodes);
-    mr_dictEmpty(clusterCtx.nodesMsgIds, NULL);
+    MR_UpdateClusterTopologyInternal(cluster);
     return REDISMODULE_OK;
 }
 

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -31,6 +31,8 @@ int MR_ClusterIsClusterMode();
 
 const char* MR_ClusterGetMyId();
 
+const char *MR_ClusterGetPassword();
+
 int MR_IsClusterInitialize();
 
 size_t MR_ClusterGetSize();

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -27,6 +27,8 @@ void MR_ClusterCopyAndSendMsgBySlot(size_t slot, functionId function, char* msg,
 
 functionId MR_ClusterRegisterMsgReceiver(MR_ClusterMessageReceiver receiver);
 
+void MR_UpdateClusterTopologyInternal(void* ctx);
+
 int MR_ClusterIsClusterMode();
 
 const char* MR_ClusterGetMyId();

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -29,7 +29,7 @@ functionId MR_ClusterRegisterMsgReceiver(MR_ClusterMessageReceiver receiver);
 
 typedef struct Cluster Cluster;
 Cluster* BuildCluster(RedisModuleString** argv, int argc, const char* password);
-void MR_UpdateClusterTopologyInternal(void* ctx);
+void MR_UpdateClusterTopologyIfNeeded(void* ctx);
 
 int MR_ClusterIsClusterMode();
 

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -27,6 +27,8 @@ void MR_ClusterCopyAndSendMsgBySlot(size_t slot, functionId function, char* msg,
 
 functionId MR_ClusterRegisterMsgReceiver(MR_ClusterMessageReceiver receiver);
 
+typedef struct Cluster Cluster;
+Cluster* BuildCluster(RedisModuleString** argv, int argc, const char* password);
 void MR_UpdateClusterTopologyInternal(void* ctx);
 
 int MR_ClusterIsClusterMode();

--- a/src/mr.c
+++ b/src/mr.c
@@ -1528,7 +1528,7 @@ void MR_FreeExecution(Execution* e) {
 
 void MR_UpdateClusterTopology() {
     RedisModuleString** argv = NULL;
-    int argc = 0;
+    int argc = 1;  // The first one is always the command name, so no need any argv for that
     const char *password = MR_ClusterGetPassword();
 
     // Updating the cluster topology is split across two threads:

--- a/src/mr.c
+++ b/src/mr.c
@@ -1526,6 +1526,28 @@ void MR_FreeExecution(Execution* e) {
     MR_FREE(e);
 }
 
+void MR_UpdateClusterTopology() {
+    RedisModuleString** argv = NULL;
+    int argc = 0;
+    const char *password = MR_ClusterGetPassword();
+
+    // Updating the cluster topology is split across two threads:
+    // 1. Redis' main thread (here): build the candidate topology and verify its
+    //    integrity (BuildCluster() returns non-NULL only if the topology is valid).
+    // 2. The event-loop thread (in MR_UpdateClusterTopologyInternal): compare the
+    //    candidate against the installed clusterCtx.CurrCluster and swap it in
+    //    (alongside other fields, e.g., .clusterSize) only if it changed.
+    //    Since this step reads and writes the cluster context it must run on the event-loop thread.
+    //
+    // Because the comparison runs later on the event-loop thread, this function
+    // cannot return a boolean indicating whether the topology actually changed or not
+    // so it returns nothing.
+    Cluster *cluster = BuildCluster(argv, argc, password);
+    if (cluster == NULL)
+        return;
+    MR_EventLoopAddTask(MR_UpdateClusterTopologyInternal, cluster);
+}
+
 static void MR_GetRedisVersion() {
     RedisModuleCallReply *reply = RedisModule_Call(mr_staticCtx, "info", "c", "server");
     assert(RedisModule_CallReplyType(reply) == REDISMODULE_REPLY_STRING);

--- a/src/mr.c
+++ b/src/mr.c
@@ -1534,7 +1534,7 @@ void MR_UpdateClusterTopology() {
     // Updating the cluster topology is split across two threads:
     // 1. Redis' main thread (here): build the candidate topology and verify its
     //    integrity (BuildCluster() returns non-NULL only if the topology is valid).
-    // 2. The event-loop thread (in MR_UpdateClusterTopologyInternal): compare the
+    // 2. The event-loop thread (in MR_UpdateClusterTopologyIfNeeded): compare the
     //    candidate against the installed clusterCtx.CurrCluster and swap it in
     //    (alongside other fields, e.g., .clusterSize) only if it changed.
     //    Since this step reads and writes the cluster context it must run on the event-loop thread.
@@ -1545,7 +1545,7 @@ void MR_UpdateClusterTopology() {
     Cluster *cluster = BuildCluster(argv, argc, password);
     if (cluster == NULL)
         return;
-    MR_EventLoopAddTask(MR_UpdateClusterTopologyInternal, cluster);
+    MR_EventLoopAddTask(MR_UpdateClusterTopologyIfNeeded, cluster);
 }
 
 static void MR_GetRedisVersion() {

--- a/src/mr.h
+++ b/src/mr.h
@@ -182,6 +182,12 @@ LIBMR_API bool MR_IsInternalCommandsExecution(const Execution* e);
 /* Free the given execution */
 LIBMR_API void MR_FreeExecution(Execution* e);
 
+/*
+ * Update cluster topology if needed (called upon topology change notifications on the main redis loop).
+ * This will eventually replace the explicit REFRESHCLUSTER (in oss) and CLUSTERSET (RE) commands.
+ */
+LIBMR_API void MR_UpdateClusterTopology();
+
 /* Initialize mr library */
 LIBMR_API int MR_Init(struct RedisModuleCtx* ctx, size_t numThreads, char *password);
 


### PR DESCRIPTION
First step - refactor SetClusterDataShortForm(): extract code into a general BuildCluster() function and call it.
Note that this required some additional cleanups (i.e., don't rely too much on clusterCtx)