### PR TITLE
MOD-16382 Some logs and cleanups

### DIFF
--- a/rust_api/libmr/mod.rs
+++ b/rust_api/libmr/mod.rs
@@ -40,7 +40,7 @@ impl Default for crate::libmr_c_raw::bindings::Record {
 
 pub type RustMRError = String;
 
-pub fn mr_init(ctx: &Context, num_threads: usize, password: Option<&str>) {
+pub fn mr_init(ctx: &Context, num_threads: usize, password: Option<&str>, topology_events: bool) {
     let password = password.map(|v| CString::new(v).unwrap());
     unsafe {
         MR_Init(
@@ -50,6 +50,7 @@ pub fn mr_init(ctx: &Context, num_threads: usize, password: Option<&str>) {
                 .as_ref()
                 .map(|v| v.as_ptr())
                 .unwrap_or(ptr::null_mut()) as *mut c_char,
+            topology_events,
         )
     };
     record::init();

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -165,7 +165,10 @@ struct ClusterCtx {
     int isOss;
     functionId networkTestMsgReceiver;
     char *password;
+    bool topologyEvents;
 }clusterCtx;
+
+bool MR_TopologyEventSeen = false;
 
 typedef struct ClusterSetCtx {
     RedisModuleBlockedClient* bc;
@@ -871,11 +874,22 @@ static Node* MR_CreateNode(Cluster* cluster, const char* id, const char* ip, uns
 }
 
 static void MR_RefreshClusterData(){
+    if (clusterCtx.topologyEvents) {
+        if (MR_TopologyEventSeen) {
+            RedisModule_Log(mr_staticCtx, "warning", "Got unexpected cluster refresh command when topology events are enabled - skipping");
+            return;
+        }
+        RedisModule_Log(mr_staticCtx, "warning", "Got unexpected cluster refresh command when topology events are enabled");
+        // Topology events are enabled, but we haven't seen one yet. maybe the redis-server doesn't support them.
+        // So to be on the safe side, we'll process the command .
+    } else {
+        RedisModule_Assert(!MR_TopologyEventSeen);  // Since no handler was registered for topology events
+        RedisModule_Log(mr_staticCtx, "notice", "Got cluster refresh command");
+    }
+
     if(clusterCtx.CurrCluster){
         MR_ClusterFree();
     }
-
-    RedisModule_Log(mr_staticCtx, "notice", "Got cluster refresh command");
 
     if(!(RedisModule_GetContextFlags(mr_staticCtx) & REDISMODULE_CTX_FLAGS_CLUSTER)){
         return;
@@ -1259,7 +1273,18 @@ void MR_UpdateClusterTopologyIfNeeded(void* ctx){
 }
 
 static int SetClusterDataShortForm(RedisModuleString** argv, int argc){
-    RedisModule_Log(mr_staticCtx, "notice", "Got cluster set command (short form)");
+    if (clusterCtx.topologyEvents) {
+        if (MR_TopologyEventSeen) {
+            RedisModule_Log(mr_staticCtx, "warning", "Got unexpected cluster set command (short form) when topology events are enabled - skipping");
+            return REDISMODULE_OK;
+        }
+        RedisModule_Log(mr_staticCtx, "warning", "Got unexpected cluster set command (short form) when topology events are enabled");
+        // Topology events are enabled, but we haven't seen one yet. maybe the redis-server doesn't support them.
+        // So to be on the safe side, we'll process the command .
+    } else {
+        RedisModule_Assert(!MR_TopologyEventSeen);  // Since no handler was registered for topology events
+        RedisModule_Log(mr_staticCtx, "notice", "Got cluster set command (short form)");
+    }
 
     // RedisModule_GetClusterNodeSlotRanges may be NULL when the host Redis
     // build does not export it (e.g. OSS Redis without the backport). Reject
@@ -1299,7 +1324,18 @@ static int SetClusterDataShortForm(RedisModuleString** argv, int argc){
 }
 
 static void SetClusterDataLongForm(RedisModuleString** argv, int argc){
-    RedisModule_Log(mr_staticCtx, "notice", "Got cluster set command (long form)");
+    if (clusterCtx.topologyEvents) {
+        if (MR_TopologyEventSeen) {
+            RedisModule_Log(mr_staticCtx, "warning", "Got unexpected cluster set command (long form) when topology events are enabled - skipping");
+            return;
+        }
+        RedisModule_Log(mr_staticCtx, "warning", "Got unexpected cluster set command (long form) when topology events are enabled");
+        // Topology events are enabled, but we haven't seen one yet. maybe the redis-server doesn't support them.
+        // So to be on the safe side, we'll process the command .
+    } else {
+        RedisModule_Assert(!MR_TopologyEventSeen);  // Since no handler was registered for topology events
+        RedisModule_Log(mr_staticCtx, "notice", "Got cluster set command (long form)");
+    }
 
     clusterCtx.CurrCluster = MR_CALLOC(1, sizeof(*clusterCtx.CurrCluster));
     InitClusterData(clusterCtx.CurrCluster, argv, argc);
@@ -1775,7 +1811,7 @@ static void MR_NetworkTest(RedisModuleCtx *ctx, const char *sender_id, uint8_t t
     RedisModule_Log(ctx, "notice", "got a nextwork test msg");
 }
 
-int MR_ClusterInit(RedisModuleCtx* rctx, char *password) {
+int MR_ClusterInit(RedisModuleCtx* rctx, char *password, bool topologyEvents) {
     clusterCtx.CurrCluster = NULL;
     clusterCtx.callbacks = array_new(MR_ClusterMessageReceiver, 10);
     clusterCtx.nodesMsgIds = mr_dictCreate(&mr_dictTypeHeapStrings, NULL);
@@ -1784,6 +1820,7 @@ int MR_ClusterInit(RedisModuleCtx* rctx, char *password) {
     clusterCtx.clusterSize = 1;
     clusterCtx.isOss = true;
     clusterCtx.password = password ? MR_STRDUP(password) : NULL;
+    clusterCtx.topologyEvents = topologyEvents;
     memset(clusterCtx.myId, '0', REDISMODULE_NODE_ID_LEN);
 
     /* Note: RedisModule_GetContextFlags() does NOT report

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1613,19 +1613,24 @@ static void MR_ClusterInfo(void* pd) {
     mr_dictEntry *entry = NULL;
     while((entry = mr_dictNext(iter))){
         Node* n = mr_dictGetVal(entry);
-        RedisModule_ReplyWithArray(ctx, 18);
+        RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_LEN);
+        long nodeLen = 0;
         RedisModule_ReplyWithStringBuffer(ctx, "id", strlen("id"));
         RedisModule_ReplyWithStringBuffer(ctx, n->id, strlen(n->id));
+        nodeLen += 2;
         RedisModule_ReplyWithStringBuffer(ctx, "ip", strlen("ip"));
         RedisModule_ReplyWithStringBuffer(ctx, n->ip, strlen(n->ip));
+        nodeLen += 2;
         RedisModule_ReplyWithStringBuffer(ctx, "port", strlen("port"));
         RedisModule_ReplyWithLongLong(ctx, n->port);
+        nodeLen += 2;
         RedisModule_ReplyWithStringBuffer(ctx, "unixSocket", strlen("unixSocket"));
         if(n->unixSocket){
             RedisModule_ReplyWithStringBuffer(ctx, n->unixSocket, strlen(n->unixSocket));
         }else{
             RedisModule_ReplyWithStringBuffer(ctx, "None", strlen("None"));
         }
+        nodeLen += 2;
         RedisModule_ReplyWithStringBuffer(ctx, "runid", strlen("runid"));
         if(n->runId){
             RedisModule_ReplyWithStringBuffer(ctx, n->runId, strlen(n->runId));
@@ -1637,15 +1642,19 @@ static void MR_ClusterInfo(void* pd) {
                 RedisModule_ReplyWithNull(ctx);
             }
         }
+        nodeLen += 2;
 
-        RedisModule_Assert(n->slotRanges->len == 1);
-        SlotRange* slotRange = mr_listFirst(n->slotRanges)->value;
-        RedisModule_ReplyWithStringBuffer(ctx, "minHslot", strlen("minHslot"));
-        RedisModule_ReplyWithLongLong(ctx, slotRange->minSlot);
-        RedisModule_ReplyWithStringBuffer(ctx, "maxHslot", strlen("maxHslot"));
-        RedisModule_ReplyWithLongLong(ctx, slotRange->maxSlot);
+        for (mr_listNode* sr = mr_listFirst(n->slotRanges); sr != NULL; sr = mr_listNextNode(sr)) {
+            SlotRange* slotRange = mr_listNodeValue(sr);
+            RedisModule_ReplyWithStringBuffer(ctx, "minHslot", strlen("minHslot"));
+            RedisModule_ReplyWithLongLong(ctx, slotRange->minSlot);
+            RedisModule_ReplyWithStringBuffer(ctx, "maxHslot", strlen("maxHslot"));
+            RedisModule_ReplyWithLongLong(ctx, slotRange->maxSlot);
+            nodeLen += 4;
+        }
         RedisModule_ReplyWithStringBuffer(ctx, "pendingMessages", strlen("pendingMessages"));
         RedisModule_ReplyWithLongLong(ctx, mr_listLength(n->pendingMessages));
+        nodeLen += 2;
 
         RedisModule_ReplyWithStringBuffer(ctx, "status", strlen("status"));
         if (n->isMe) {
@@ -1661,6 +1670,8 @@ static void MR_ClusterInfo(void* pd) {
         } else if (n->status == NodeStatus_Uninitialized) {
             RedisModule_ReplyWithStringBuffer(ctx, "uninitialized", strlen("uninitialized"));
         }
+        nodeLen += 2;
+        RedisModule_ReplySetArrayLength(ctx, nodeLen);
     }
     mr_dictReleaseIterator(iter);
     RedisModule_FreeThreadSafeContext(ctx);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1094,7 +1094,7 @@ static int ParseShardEntry(RedisModuleString** argv, int argc, int index,
     return index;
 }
 
-Cluster* BuildCluster(RedisModuleString** argv, int argc, const char* password) {
+Cluster* MR_BuildCluster(RedisModuleString** argv, int argc, const char* password) {
     size_t numNodes;
     char **nodeList = RedisModule_GetClusterNodesList(mr_staticCtx, &numNodes);
     if (!nodeList) {
@@ -1164,12 +1164,15 @@ Cluster* BuildCluster(RedisModuleString** argv, int argc, const char* password) 
     }
     RedisModule_FreeClusterNodesList(nodeList);
 
-    if (cluster != NULL && coveredSlots != NUMBER_OF_SLOTS) {
+    if (cluster == NULL)
+        return NULL;
+
+    if (coveredSlots != NUMBER_OF_SLOTS) {
         RedisModule_Log(mr_staticCtx, "warning",
             "Cluster topology covers %zu of %d slots; rejecting topology",
             coveredSlots, NUMBER_OF_SLOTS);
         FreeCluster(cluster);
-        cluster = NULL;
+        return NULL;
     }
 
     return cluster;
@@ -1219,9 +1222,13 @@ void MR_UpdateClusterTopologyIfNeeded(void* ctx){
     RedisModule_Assert(cluster != NULL);
 
     if (SameCluster(cluster, clusterCtx.CurrCluster)) {
+        RedisModule_Log(mr_staticCtx, "notice", "Skipping cluster topology update, same cluster topology");
         FreeCluster(cluster);
         return;
     }
+
+    RedisModule_Log(mr_staticCtx, "notice", "Updating cluster topology, number of masters: %ld",
+                    (long)mr_dictSize(cluster->nodes));
 
     if (clusterCtx.CurrCluster)
         MR_ClusterFree();
@@ -1283,7 +1290,7 @@ static int SetClusterDataShortForm(RedisModuleString** argv, int argc){
         RedisModule_Assert(0);
     }
 
-    Cluster* cluster = BuildCluster(argv, argc, password);
+    Cluster* cluster = MR_BuildCluster(argv, argc, password);
     if (!cluster)
         return REDISMODULE_ERR;
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1272,6 +1272,12 @@ void MR_UpdateClusterTopologyIfNeeded(void* ctx){
     mr_dictEmpty(clusterCtx.nodesMsgIds, NULL);
 }
 
+void MR_UpdateClusterTopologyIfNeededUnderLock(void* ctx){
+    RedisModule_ThreadSafeContextLock(mr_staticCtx);
+    MR_UpdateClusterTopologyIfNeeded(ctx);
+    RedisModule_ThreadSafeContextUnlock(mr_staticCtx);
+}
+
 static int SetClusterDataShortForm(RedisModuleString** argv, int argc){
     if (clusterCtx.topologyEvents) {
         if (MR_TopologyEventSeen) {

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -41,7 +41,10 @@ int MR_IsClusterInitialize();
 
 size_t MR_ClusterGetSize();
 
-int MR_ClusterInit(RedisModuleCtx* rctx, char *password);
+int MR_ClusterInit(RedisModuleCtx* rctx, char *password, bool topologyEvents);
+
+// Set to true once a cluster topology-change event is seen
+extern bool MR_TopologyEventSeen;
 
 size_t MR_ClusterGetSlotByKey(const char* key, size_t len);
 

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -28,7 +28,7 @@ void MR_ClusterCopyAndSendMsgBySlot(size_t slot, functionId function, char* msg,
 functionId MR_ClusterRegisterMsgReceiver(MR_ClusterMessageReceiver receiver);
 
 typedef struct Cluster Cluster;
-Cluster* BuildCluster(RedisModuleString** argv, int argc, const char* password);
+Cluster* MR_BuildCluster(RedisModuleString** argv, int argc, const char* password);
 void MR_UpdateClusterTopologyIfNeeded(void* ctx);
 
 int MR_ClusterIsClusterMode();

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -30,6 +30,7 @@ functionId MR_ClusterRegisterMsgReceiver(MR_ClusterMessageReceiver receiver);
 typedef struct Cluster Cluster;
 Cluster* MR_BuildCluster(RedisModuleString** argv, int argc, const char* password);
 void MR_UpdateClusterTopologyIfNeeded(void* ctx);
+void MR_UpdateClusterTopologyIfNeededUnderLock(void* ctx);
 
 int MR_ClusterIsClusterMode();
 

--- a/src/mr.c
+++ b/src/mr.c
@@ -1533,7 +1533,7 @@ void MR_UpdateClusterTopology() {
 
     // Updating the cluster topology is split across two threads:
     // 1. Redis' main thread (here): build the candidate topology and verify its
-    //    integrity (BuildCluster() returns non-NULL only if the topology is valid).
+    //    integrity (MR_BuildCluster() returns non-NULL only if the topology is valid).
     // 2. The event-loop thread (in MR_UpdateClusterTopologyIfNeeded): compare the
     //    candidate against the installed clusterCtx.CurrCluster and swap it in
     //    (alongside other fields, e.g., .clusterSize) only if it changed.
@@ -1542,7 +1542,7 @@ void MR_UpdateClusterTopology() {
     // Because the comparison runs later on the event-loop thread, this function
     // cannot return a boolean indicating whether the topology actually changed or not
     // so it returns nothing.
-    Cluster *cluster = BuildCluster(argv, argc, password);
+    Cluster *cluster = MR_BuildCluster(argv, argc, password);
     if (cluster == NULL)
         return;
     MR_EventLoopAddTask(MR_UpdateClusterTopologyIfNeeded, cluster);

--- a/src/mr.c
+++ b/src/mr.c
@@ -1527,6 +1527,7 @@ void MR_FreeExecution(Execution* e) {
 }
 
 void MR_UpdateClusterTopology() {
+    MR_TopologyEventSeen = true;
     RedisModuleString** argv = NULL;
     int argc = 1;  // The first one is always the command name, so no need any argv for that
     const char *password = MR_ClusterGetPassword();
@@ -1587,11 +1588,11 @@ static void MR_GetRedisVersion() {
     RedisModule_FreeCallReply(reply);
 }
 
-int MR_Init(RedisModuleCtx* ctx, size_t numThreads, char *password) {
+int MR_Init(RedisModuleCtx* ctx, size_t numThreads, char *password, bool topologyEvents) {
     mr_staticCtx = RedisModule_GetDetachedThreadSafeContext(ctx);
     MR_GetRedisVersion();
 
-    if (MR_ClusterInit(ctx, password) != REDISMODULE_OK) {
+    if (MR_ClusterInit(ctx, password, topologyEvents) != REDISMODULE_OK) {
         return REDISMODULE_ERR;
     }
 

--- a/src/mr.c
+++ b/src/mr.c
@@ -1535,7 +1535,7 @@ void MR_UpdateClusterTopology() {
     // Updating the cluster topology is split across two threads:
     // 1. Redis' main thread (here): build the candidate topology and verify its
     //    integrity (MR_BuildCluster() returns non-NULL only if the topology is valid).
-    // 2. The event-loop thread (in MR_UpdateClusterTopologyIfNeeded): compare the
+    // 2. The event-loop thread (in the lock-protected MR_UpdateClusterTopologyIfNeeded): compare the
     //    candidate against the installed clusterCtx.CurrCluster and swap it in
     //    (alongside other fields, e.g., .clusterSize) only if it changed.
     //    Since this step reads and writes the cluster context it must run on the event-loop thread.
@@ -1546,7 +1546,7 @@ void MR_UpdateClusterTopology() {
     Cluster *cluster = MR_BuildCluster(argv, argc, password);
     if (cluster == NULL)
         return;
-    MR_EventLoopAddTask(MR_UpdateClusterTopologyIfNeeded, cluster);
+    MR_EventLoopAddTask(MR_UpdateClusterTopologyIfNeededUnderLock, cluster);
 }
 
 static void MR_GetRedisVersion() {

--- a/src/mr.h
+++ b/src/mr.h
@@ -189,7 +189,7 @@ LIBMR_API void MR_FreeExecution(Execution* e);
 LIBMR_API void MR_UpdateClusterTopology();
 
 /* Initialize mr library */
-LIBMR_API int MR_Init(struct RedisModuleCtx* ctx, size_t numThreads, char *password);
+LIBMR_API int MR_Init(struct RedisModuleCtx* ctx, size_t numThreads, char *password, bool topologyEvents);
 
 /* Resize the execution thread pool with a new size if worker threads were never started.
  * Requires MR_Init() to have created the pool. Returns REDISMODULE_ERR if the pool does not

--- a/tests/mr_test_module/pytests/common.py
+++ b/tests/mr_test_module/pytests/common.py
@@ -97,7 +97,7 @@ def verifyClusterInitialized(env):
             nodes = res[4]
             allConnected = True
             for n in nodes:
-                status = n[17]
+                status = n[-1]
                 if status != 'connected':
                     allConnected = False
             if not allConnected:

--- a/tests/mr_test_module/src/lib.rs
+++ b/tests/mr_test_module/src/lib.rs
@@ -861,7 +861,7 @@ fn init_func(ctx: &Context, args: &[RedisString]) -> Status {
     let pass = args_iter
         .next()
         .map(|v| Some(v.to_string())).flatten();
-    mr_init(ctx, 5, pass.as_deref());
+    mr_init(ctx, 5, pass.as_deref(), true);
 
     KeysReader::register();
     Status::Ok


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes cluster configuration paths and threading around topology swaps; mis-handling the topology-events vs legacy-command interaction could leave cluster state stale or ignore needed fallbacks.
> 
> **Overview**
> Adds a **`topologyEvents`** flag through **`MR_Init`** / **`mr_init`** so modules can prefer Redis topology notifications over manual cluster commands.
> 
> When topology events are enabled and at least one notification was handled (`MR_TopologyEventSeen`), **REFRESHCLUSTER** and **CLUSTERSET** (short/long) are **skipped** with warnings; if events are enabled but none arrived yet, those commands still run as a fallback. **`MR_UpdateClusterTopology`** sets the seen flag and schedules updates via **`MR_UpdateClusterTopologyIfNeededUnderLock`** (thread-safe context lock on the event loop).
> 
> **`BuildCluster`** is renamed **`MR_BuildCluster`** with clearer NULL handling on incomplete slot coverage. **`INFOCLUSTER`** node replies use a **variable-length** array and emit **all** slot ranges per node (not a single range). Tests read node **status** from **`n[-1]`** instead of a fixed index; the test module initializes with **`topology_events: true`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57b1c2a002fb9a6727bd83e0a2702d4398001eec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->