### PR TITLE
MOD-16951 Eagerly connect to shards on topology-change notification

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1251,6 +1251,20 @@ void MR_UpdateClusterTopologyIfNeeded(void* ctx){
 
     clusterCtx.clusterSize = mr_dictSize(cluster->nodes);
     mr_dictEmpty(clusterCtx.nodesMsgIds, NULL);
+
+    // Eagerly establish the inter-shard connections for the freshly installed
+    // topology. Historically the topology was set via CLUSTERSET/REFRESHCLUSTER
+    // which the caller (e.g. DMC, or the test harness) followed with an explicit
+    // FORCESHARDSCONNECTION. The topology-change notification path has no such
+    // follow-up, so without this the connections would only be created lazily on
+    // the first fan-out command. On a "cold" coordinator that first map request
+    // is then dropped ("message was not sent because status is not connected")
+    // while the connection is still being established, the reduce step never
+    // receives the shard responses, and the execution aborts with
+    // "execution max idle reached" (MOD-16951). Connecting here keeps the
+    // connections warm before any command arrives; MR_ClusterConnectToShards()
+    // only acts on Uninitialized nodes, so it is safe to call on every swap.
+    MR_ClusterConnectToShards();
 }
 
 static int SetClusterDataShortForm(RedisModuleString** argv, int argc){


### PR DESCRIPTION
## Summary

Since #105 (MOD-16382) the cluster topology is installed from Redis' `ClusterTopologyChange` notifications via `MR_UpdateClusterTopologyIfNeeded`, instead of the explicit `CLUSTERSET`/`REFRESHCLUSTER` + `FORCESHARDSCONNECTION` flow. That notification path installs the topology but never establishes the inter-shard connections, so they were only opened **lazily on the first fan-out command**.

On a "cold" coordinator the first `TS.MRANGE`/`TS.QUERYINDEX`/`TS.MGET`/`TS.MREVRANGE` map request is dropped while the connection is still being established (`message was not sent because status is not connected`), the reduce step never receives the shard responses, and the execution aborts with `execution max idle reached` (~5s) — the client gets no reply and blocks until its read timeout.

## Fix

Establish the connections eagerly right after installing a new topology in `MR_UpdateClusterTopologyIfNeeded`, so they are warm before any command arrives.

`MR_ClusterConnectToShards()` skips `isMe` and only calls `MR_ConnectToShard()` on `NodeStatus_Uninitialized` nodes, so it is safe to call on every topology swap and is a no-op when the topology is unchanged (the function early-returns on `SameCluster`).

## Notes

- One-line change (+ explanatory comment) in `src/cluster.c`.
- Ref: MOD-16951.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster inter-shard connection timing on topology swaps, which affects multi-shard command fan-out, but reuses the existing idempotent connect helper limited to uninitialized nodes.
> 
> **Overview**
> After **Redis `ClusterTopologyChange`** installs topology via `MR_UpdateClusterTopologyIfNeeded`, inter-shard links were only opened on the **first fan-out command**. On a cold coordinator the first multi-shard map step could be dropped while still connecting (`message was not sent because status is not connected`), starving the reduce phase and hitting **execution max idle reached** (MOD-16951).
> 
> The change calls **`MR_ClusterConnectToShards()`** immediately after a successful topology swap so connections warm up before client traffic. That helper only touches **`NodeStatus_Uninitialized`** peers (not `isMe`), matching the old explicit **`FORCESHARDSCONNECTION`** step that CLUSTERSET/REFRESHCLUSTER callers used to run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c72681604f4094d86d4ffbc0356751817f5dc33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->