### PR TITLE
MOD-16951 Gate inter-shard TLS on tls-cluster for OSS cluster

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -549,6 +549,26 @@ static int checkTLS(char** client_key, char** client_cert, char** ca_cert, char*
 
     clusterTls = getConfigValue(mr_staticCtx, "tls-cluster");
     if (!clusterTls || strcmp(clusterTls, "yes")) {
+        /* MOD-16951: when the topology is built from the native cluster view
+         * (RedisModule_GetClusterNodeInfo -- used by the topology-change event,
+         * REFRESHCLUSTER and short-form CLUSTERSET; see MR_RefreshClusterData /
+         * BuildCluster), the peer port we dial is the PLAINTEXT node port whenever
+         * tls-cluster is off. So for those paths the inter-shard TLS decision must be
+         * gated strictly on tls-cluster: a bare tls-port (external TLS clients over an
+         * otherwise-plaintext bus) must NOT force TLS here, or we'd open a TLS handshake
+         * against a plaintext port -> the peer's RESP parser blocks on a reply that never
+         * comes and multi-shard commands (TS.MRANGE / TS.QUERYINDEX) hang until
+         * "execution max idle reached".
+         *
+         * Long-form CLUSTERSET is the exception: there the caller (e.g. the enterprise
+         * DMC) supplies explicit shard endpoints, which may be TLS ports, so it keeps the
+         * historical tls-port fallback. */
+        bool explicitEndpoints = clusterCtx.CurrCluster &&
+            IsLongFormClusterSet(clusterCtx.CurrCluster->clusterSetCommandSize);
+        if (!explicitEndpoints) {
+            ret = 0;
+            goto done;
+        }
         tlsPort = getConfigValue(mr_staticCtx, "tls-port");
         if (!tlsPort || !strcmp(tlsPort, "0")) {
             ret = 0;


### PR DESCRIPTION
## Summary

Fixes **MOD-16951**: in an OSS cluster, the first cross-shard TimeSeries command
(`TS.MRANGE` / `TS.QUERYINDEX` / `TS.MGET`) stalls ~5s and returns
*"A multi-keys command failed because at least one shard did not reply within the
given timeframe."* — a regression first shipped in the 8.9.90 / M4 build.

## Root cause — inter-shard TLS decision disagrees with the port we dial

`checkTLS()` decides whether LibMR opens inter-shard connections over TLS. Since
LibMR #8 it enables TLS when **either** `tls-cluster yes` **or** a bare `tls-port`
is set:

```c
clusterTls = getConfigValue(mr_staticCtx, "tls-cluster");
if (!clusterTls || strcmp(clusterTls, "yes")) {
    tlsPort = getConfigValue(mr_staticCtx, "tls-port");
    if (!tlsPort || !strcmp(tlsPort, "0")) {   // no tls-port -> plaintext
        ret = 0; goto done;
    }
    // tls-port set -> fall through -> use TLS
}
```

But the peer **address** LibMR dials comes from `RedisModule_GetClusterNodeInfo()`
(`BuildCluster` / `MR_RefreshClusterData`), which returns the node's **plaintext**
data port whenever `tls-cluster` is off. So on a shard configured with
`tls-cluster no` + `tls-port <p>` (TLS available for external clients over an
otherwise-plaintext cluster bus — a common deployment, and exactly the
client-libs M4 test cluster), the two disagree:

* `checkTLS` → *"use TLS"* (because `tls-port` is set)
* `BuildCluster` → dials the **plaintext** port

LibMR then sends a **TLS ClientHello to the peer's plaintext port**. Confirmed on
the M4 cluster via `tcpdump` on loopback:7480 — the 1533 bytes are a TLS 1.3
ClientHello (`16 03 01 … 13 02 13 03 c0 2c c0 30`). The peer's RESP parser blocks
on a command that never completes (`CLIENT LIST` on the peer: `qbuf=1533
tot-cmds=0 tot-net-out=0` — bytes read once, zero commands parsed, no reply), so
`timeseries.HELLO` is never processed, the fan-out map is never delivered, and the
reduce step idles out after 5s.

## Why this regressed in 8.9.90

The mismatch is not new, but it was **latent** until RTS became cluster-aware via
the topology-change event (**MOD-16382**, #105). Before that, OSS TS multi-shard
fan-out over this native `GetClusterNodeInfo` view wasn't exercised in this
configuration, so `checkTLS` and the dialed port never collided in practice.
MOD-16382 is the **trigger**, not the defect.

## The fix

Gate the inter-shard TLS decision for **OSS** strictly on `tls-cluster yes` — the
only value consistent with the plaintext port that `GetClusterNodeInfo` hands us
when the bus is plaintext. The **enterprise (DMC) path is left byte-for-byte
unchanged**: it keeps the historical `tls-port` fallback, because there the DMC
supplies the shard endpoints and that fallback has long been how enterprise
enables inter-shard TLS while `tls-cluster` is not `"yes"`. The OSS/enterprise
split (`clusterCtx.isOss`) is already the idiom in this file (internal-secret AUTH,
command flags).

```c
if (!clusterTls || strcmp(clusterTls, "yes")) {
    if (clusterCtx.isOss) {          // OSS: dialed port is plaintext -> never TLS here
        ret = 0; goto done;
    }
    tlsPort = getConfigValue(mr_staticCtx, "tls-port");   // enterprise: unchanged
    if (!tlsPort || !strcmp(tlsPort, "0")) {
        ret = 0; goto done;
    }
}
```

## Verification (fails-before / passes-after, same env)

Built the `redistimeseries.so` for linux-arm64 with and without this change, baked
each into an image `FROM redislabs/client-libs-test:custom-29557896054-debian`
(the exact M4 build, `tls-cluster no`, `port 7479`, `tls-port 8479`), stood up the
3-master + 3-replica cluster, and timed the first cross-shard command from a cold
coordinator:

| build | `TS.QUERYINDEX` | `TS.MRANGE` | reply |
|---|---|---|---|
| **before** (unfixed) | **5.161s** | **5.148s** | *"…at least one shard did not reply…"* |
| **after** (this fix) | **0.120s** | **0.112s** | real cross-shard results, no error |

After the fix the server log shows **zero** `execution max idle reached` and the
inter-shard `timeseries.HELLO` handshake completes over the plaintext connection.

### Reproduce

On a dual-port OSS cluster (`tls-cluster no`, plaintext `port` + a non-zero
`tls-port` with certs — e.g. the client-libs `cluster-stable` service,
`TLS_ENABLED=yes NODES=6 REPLICAS=1`):

```
redis-cli -p 7479 -a <pass> TS.CREATE ts:{k1} LABELS grp g   # a few, cross-shard
redis-cli -p 7479 -a <pass> TS.QUERYINDEX grp=g              # stalls ~5s before, ~0.1s after
```

The natural automated regression gate is the client-libs dual-TLS OSS-cluster
integration test (the jedis `TimeSeriesClusterCommandsIT` that surfaced this).
RLTest can't currently model this config: it hardcodes `--tls-cluster yes` for any
TLS cluster, so it never exercises the "TLS client port + plaintext bus" case.

## Scope / safety

* OSS plaintext-only clusters: unchanged (no `tls-port`).
* OSS `tls-cluster yes`: unchanged (TLS as before).
* OSS `tls-cluster no` + `tls-port`: **fixed** — inter-shard now uses the plaintext
  port it actually dials, instead of a TLS handshake against it.
* Enterprise/DMC: **unchanged** (still honors the `tls-port` fallback).

Supersedes #110 (eager-connect) — that theory was disproven: the send path already
queues to `pendingMessages` (never drops), and connecting earlier still deadlocks
at the never-completing TLS-to-plaintext HELLO.

Follow-ups (separate): bump the RTS LibMR pin to include this commit, and
cherry-pick to the 8.10 release branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when inter-shard connections use TLS versus plaintext; misclassification of topology form could break enterprise DMC TLS endpoints or reintroduce the plaintext/TLS mismatch on OSS dual-port clusters.
> 
> **Overview**
> Fixes **MOD-16951**: cross-shard TimeSeries commands (`TS.MRANGE`, `TS.QUERYINDEX`, etc.) timing out when the cluster bus is plaintext (`tls-cluster no`) but a separate `tls-port` is configured for external clients.
> 
> **`checkTLS()`** no longer treats a non-zero **`tls-port`** as “use TLS for LibMR inter-shard links” unless the active topology came from **long-form `CLUSTERSET`** (explicit `ADDR` endpoints, e.g. enterprise DMC). For topologies built from the native cluster view (**`GetClusterNodeInfo`**, refresh, short-form `CLUSTERSET`, topology-change paths), inter-shard TLS is enabled only when **`tls-cluster yes`**—matching the plaintext ports those paths dial. Without this, LibMR could send a TLS handshake to a plaintext shard port, block the peer, and stall multi-shard fan-out until the execution idle timeout.
> 
> Long-form **`CLUSTERSET`** still keeps the historical **`tls-port`** fallback when `tls-cluster` is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1f8f832d6d0e8b7262eb19d4cfa3b77dc247af8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->