### PR TITLE
MOD-16382 Fix Execution leak on topology-change abort / idle-timeout race

### DIFF
--- a/src/mr.c
+++ b/src/mr.c
@@ -57,11 +57,14 @@ typedef struct RemoteFunctionDef {
 
 typedef struct Step Step;
 
-typedef void (*ExecutionTaskCallback)(Execution* e, void* pd);
+// Returns true if the callback disposed (freed) the execution, in which case the
+// caller (MR_ExecutionMain) must not touch it afterwards. Returns false otherwise,
+// so the caller keeps draining the execution's task queue.
+typedef bool (*ExecutionTaskCallback)(Execution* e, void* pd);
 
 /* functions declarations */
 static void MR_ExecutionAddTask(Execution* e, ExecutionTaskCallback callback, void* pd);
-static void MR_RunExecution(Execution* e, void* pd);
+static bool MR_RunExecution(Execution* e, void* pd);
 static Record* MR_RunStep(Execution* e, Step* s);
 void MR_FreeExecution(Execution* e);
 
@@ -609,7 +612,7 @@ static size_t MR_PerformStepDoneOp(Execution* e, size_t stepIndex) {
 }
 
 /* Execution task */
-static void MR_StepDone(Execution* e, void* pd) {
+static bool MR_StepDone(Execution* e, void* pd) {
     RedisModuleString* payload = pd;
 
     /* deserialize record, set it on the right step. */
@@ -636,10 +639,11 @@ static void MR_StepDone(Execution* e, void* pd) {
         /* All shards are done running the step, we can continue the execution. */
         MR_RunExecution(e, NULL);
     }
+    return false;  // never disposes the execution here
 }
 
 /* Execution task */
-static void MR_SetRecord(Execution* e, void* pd) {
+static bool MR_SetRecord(Execution* e, void* pd) {
     RedisModuleString* payload = pd;
 
     /* deserialize record, set it on the right step. */
@@ -668,6 +672,7 @@ static void MR_SetRecord(Execution* e, void* pd) {
         /* There is enough records to process, lets continue running. */
         MR_RunExecution(e, NULL);
     }
+    return false;  // never disposes the execution here
 }
 
 /* Remote function call, runs on the event loop */
@@ -976,8 +981,9 @@ static bool MR_ExecutionInvokeCallback(Execution* e, ExecutionCallbackData* call
     return true;
 }
 
-static void MR_DisposeExecution(Execution* e, void* pd) {
+static bool MR_DisposeExecution(Execution* e, void* pd) {
     MR_FreeExecution(e);
+    return true;  // always disposes the execution
 }
 
 /* runs on the event loop, remove the execution from the
@@ -1027,7 +1033,7 @@ static void MR_NotifyDone(RedisModuleCtx *ctx, const char *sender_id, uint8_t ty
     }
 }
 
-static void MR_RunExecution(Execution* e, void* pd) {
+static bool MR_RunExecution(Execution* e, void* pd) {
     MR_ExecutionInvokeCallback(e, &e->callbacks.resume);
     if (MR_RunExecutionInternal(e)) {
         /* we are done, invoke on done callback and perform termination process. */
@@ -1038,7 +1044,7 @@ static void MR_RunExecution(Execution* e, void* pd) {
             executionDone = executionDone || MR_IsInternalCommandsExecution(e); // or we don't need a NOTIFY_DONE message
             if (executionDone) {
                 MR_EventLoopAddTask(MR_DeleteExecution, e);
-                return;
+                return false;  // disposal happens later via MR_DeleteExecution -> MR_DisposeExecution
             }
         }
         if (!(e->flags & ExecutionFlag_Initiator)) {
@@ -1047,6 +1053,7 @@ static void MR_RunExecution(Execution* e, void* pd) {
     } else {
         MR_ExecutionInvokeCallback(e, &e->callbacks.hold);
     }
+    return false;  // never disposes the execution here
 }
 
 /* Remote function call, runs on the event loop */
@@ -1279,7 +1286,7 @@ static void MR_ExecutionSerialize(mr_BufferWriter* buffWriter, Execution* e) {
 }
 
 /* Execution task distribute callback */
-static void MR_ExecutionDistribute(Execution* e, void* pd) {
+static bool MR_ExecutionDistribute(Execution* e, void* pd) {
     mr_Buffer buff;
     mr_BufferInitialize(&buff);
     mr_BufferWriter buffWriter;
@@ -1293,15 +1300,22 @@ static void MR_ExecutionDistribute(Execution* e, void* pd) {
     MR_ClusterSendMsg(NULL, fid, buff.buff, buff.size);
 
     /* now we wait for shards to respond that they got the execution */
+    return false;  // never disposes the execution here
 }
 
-static void MR_ExecutionTimedOutInternal(Execution* e, void* pd) {
+static bool MR_ExecutionTimedOutInternal(Execution* e, void* pd) {
     e->errors = array_append(e->errors, MR_ErrorRecordCreate("execution max idle reached"));
-    /* we are done, invoke on done callback. */
+    /* We are done: invoke the on-done callback and free the execution. If the done
+     * callback was already fired (a normal completion won the race and nulled it),
+     * a MR_DisposeExecution is already queued to free the execution - so we must NOT
+     * free it here (that would double-free). Return false so MR_ExecutionMain keeps
+     * draining the task queue and that pending MR_DisposeExecution still runs;
+     * otherwise the execution (and its results) would leak. */
     if (!MR_ExecutionInvokeCallback(e, &e->callbacks.done))
-        return;
+        return false;
     e->callbacks.done.callback = NULL; // make sure the done callback will not be called again.
     MR_FreeExecution(e);
+    return true;
 }
 
 /* runs on the event loop */
@@ -1317,12 +1331,19 @@ static void MR_ExecutionTimedOut(void* ctx) {
 }
 
 // Thread pool task: fires the done callback with a cluster topology change error
-static void MR_ExecutionAbortedOnClusterChange(Execution* e, void* pd) {
+static bool MR_ExecutionAbortedOnClusterChange(Execution* e, void* pd) {
     e->errors = array_append(e->errors, MR_ErrorRecordCreate("cluster topology changed"));
+    /* We are done: invoke the on-done callback and free the execution. If the done
+     * callback was already fired (a normal completion won the race and nulled it),
+     * a MR_DisposeExecution is already queued to free the execution - so we must NOT
+     * free it here (that would double-free). Return false so MR_ExecutionMain keeps
+     * draining the task queue and that pending MR_DisposeExecution still runs;
+     * otherwise the execution (and its results) would leak. */
     if (!MR_ExecutionInvokeCallback(e, &e->callbacks.done))
-        return;
+        return false;
     e->callbacks.done.callback = NULL; /* make sure the done callback will not be called again */
     MR_FreeExecution(e);
+    return true;
 }
 
 static void MR_ExecutionMain(void* pd) {
@@ -1333,11 +1354,13 @@ static void MR_ExecutionMain(void* pd) {
     pthread_mutex_unlock(&e->eLock);
 
     ExecutionTaskCallback callback = task->callback;
-    callback(e, task->pd);
-    if (callback == MR_DisposeExecution ||
-        callback == MR_ExecutionTimedOutInternal ||
-        callback == MR_ExecutionAbortedOnClusterChange) {
-        // These callbacks dispose the execution; we must not touch it afterwards
+    if (callback(e, task->pd)) {
+        // The callback disposed (freed) the execution; we must not touch it afterwards.
+        // Note: MR_ExecutionTimedOutInternal / MR_ExecutionAbortedOnClusterChange return
+        // false (do NOT dispose) when their done callback was already fired by a racing
+        // normal completion, which leaves a MR_DisposeExecution queued behind this task.
+        // Falling through in that case lets us drain the queue so that pending
+        // MR_DisposeExecution runs and frees the execution (otherwise it would leak).
         return;
     }
 


### PR DESCRIPTION
## Summary

Initiator `TS.MRANGE`/`TS.QUERYINDEX` **Executions** (and all their parsed result Records) leak when a cluster **topology change** aborts in-flight executions. Surfaced by the topology-change flow tests in [RedisTimeSeries#2116](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2116) — the `linux-sanitizer / x64-jammy-oss_cluster` job reports:

```
Direct leak of 1632 byte(s) in 6 object(s):
    MR_ExecutionAlloc  src/mr.c:516
    MR_CreateExecution src/mr.c:542
    TSDB_mrange_MR     ... (initiator, internal-command fan-out)
Indirect leak of 2.45 MB in 599 object(s): parsed Series/chunks/labels off e->results
SUMMARY: AddressSanitizer: 2762418 byte(s) leaked in 7973 allocation(s).
```

The 6 `Execution` objects are the **only** direct-leak root; everything else is indirect, hanging off their `results` arrays.

## Root cause

`MR_ExecutionAbortedOnClusterChange` and `MR_ExecutionTimedOutInternal` **early-return without `MR_FreeExecution`** when the done callback was already fired by a racing normal completion (`done.callback == NULL`). But `MR_ExecutionMain` unconditionally treated those two callbacks (alongside `MR_DisposeExecution`) as "the execution was disposed" and returned **without popping the task or rescheduling**.

`MR_RunExecution` always nulls `done.callback` *before* it queues `MR_DeleteExecution` → `MR_DisposeExecution`. So whenever a `MR_DisposeExecution` is pending, `done.callback` is already NULL — exactly the condition that makes the abort/timeout handler take its no-free branch.

Interleaving (EL = event loop, TP = thread pool), all shards have replied:

1. **[EL]** last shard reply → results parsed, completion gate holds → schedule `MR_RunExecution`. `e->tasks=[RUN]`.
2. **[EL]** topology change → `MR_ClusterFree` → `MR_AbortRunningExecutions`: cancels idle timer, `dictDelete`s `e`, appends abort. `e->tasks=[RUN, ABORT]`.
3. **[TP]** `MR_RunExecution` fires done, **nulls it**, schedules `MR_DeleteExecution`; RUN popped, runner reschedules. `e->tasks=[ABORT]`.
4. **[EL]** `MR_DeleteExecution`: dict delete is a no-op, appends `MR_DisposeExecution`. `e->tasks=[ABORT, DISPOSE]`.
5. **[TP]** `MR_ExecutionAbortedOnClusterChange` → `done==NULL` → early-return (no free) → `MR_ExecutionMain` returns **without popping/rescheduling**.

Terminal state: `e->tasks=[ABORT, DISPOSE]` frozen, `e` out of the dict, idle timer gone, refCount stuck at 1. `MR_DisposeExecution` never runs → the Execution and its results leak permanently (survives to shutdown LeakSanitizer).

This has been latent since **MOD-14439** (abort in-flight executions on topology change) but only became reachable once **MOD-16382** began installing topology from `ClusterTopologyChange` notifications, which runs `MR_ClusterFree → MR_AbortRunningExecutions` on **every** real topology change.

## Fix

Make `ExecutionTaskCallback` return whether it disposed (freed) the execution. `MR_ExecutionMain` skips post-processing only when the callback actually disposed it; otherwise it drains the task queue as before, so a pending `MR_DisposeExecution` still runs. The abort/idle-timeout handlers return `false` on the early-return path (they did not free) — fixing the leak while preserving a single free.

**Why not just always-free in the handlers** (an earlier approach): on the current code that is a **use-after-free**. When the abort runs *before* the already-scheduled `MR_DeleteExecution`, freeing in the handler leaves `MR_DeleteExecution` operating on freed memory. Deferring to the queued `MR_DisposeExecution` keeps exactly one free and no double-free.

## Testing

- `make -C src/` builds cleanly (no new warnings).
- Verified against the ASAN signature above; the fix targets the exact stranded-`MR_DisposeExecution` path. The RTS#2116 `linux-sanitizer / x64-jammy-oss_cluster` job is the end-to-end reproducer — after bumping the RTS LibMR pin to this commit it should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches execution lifecycle and freeing on cluster abort/timeout race paths in core map-reduce threading; logic is narrow but memory-safety critical.
> 
> **Overview**
> Fixes **Execution** and result **Record** leaks when cluster topology change or idle timeout races normal completion on initiator map-reduce runs.
> 
> **`ExecutionTaskCallback`** now returns whether the task **actually freed** the execution. **`MR_ExecutionMain`** only stops without popping/rescheduling when that return is **true** (e.g. **`MR_DisposeExecution`**), instead of treating abort/timeout handlers the same even when they did not free.
> 
> **`MR_ExecutionAbortedOnClusterChange`** and **`MR_ExecutionTimedOutInternal`** return **`false`** when the done callback was already cleared by a racing **`MR_RunExecution`**, so the runner keeps draining the queue and a queued **`MR_DisposeExecution`** still runs—avoiding stranded tasks and leaks without double-freeing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc32e5488ef55b89a511ac4ddd8a1b9b7cf6b86c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->