### PR TITLE
MOD-16956 Fix topology-change memory-safety: HELLO use-after-free + ClusterSetCtx leak

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1457,12 +1457,27 @@ static int MR_ClusterSetFromShard(RedisModuleCtx *ctx, RedisModuleString **argv,
     return REDISMODULE_OK;
 }
 
-int MR_ClusterHello(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
+/* runs in the event loop so it is safe to read the cluster topology here.
+ * clusterCtx.CurrCluster is owned by the event-loop thread, which frees and swaps
+ * it on topology changes (MR_UpdateClusterTopologyIfNeeded). Reading it directly
+ * from the command handler on the main thread races that free -> use-after-free,
+ * so we defer the read to the event loop, like MR_ClusterInfo/MR_ClusterRefresh. */
+static void MR_ClusterHelloReply(void* pd){
+    RedisModuleBlockedClient* bc = pd;
+    RedisModuleCtx* ctx = RedisModule_GetThreadSafeContext(bc);
     if(!clusterCtx.CurrCluster){
         RedisModule_Log(mr_staticCtx, "warning", "Got hello msg while cluster is NULL");
-        return RedisModule_ReplyWithError(ctx, CLUSTER_ERROR" NULL cluster state on hello msg");
+        RedisModule_ReplyWithError(ctx, CLUSTER_ERROR" NULL cluster state on hello msg");
+    } else {
+        RedisModule_ReplyWithStringBuffer(ctx, clusterCtx.CurrCluster->runId, strlen(clusterCtx.CurrCluster->runId));
     }
-    RedisModule_ReplyWithStringBuffer(ctx, clusterCtx.CurrCluster->runId, strlen(clusterCtx.CurrCluster->runId));
+    RedisModule_FreeThreadSafeContext(ctx);
+    RedisModule_UnblockClient(bc, NULL);
+}
+
+int MR_ClusterHello(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
+    RedisModuleBlockedClient* bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
+    MR_EventLoopAddTask(MR_ClusterHelloReply, bc);
     return REDISMODULE_OK;
 }
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1396,16 +1396,24 @@ static void MR_ClusterSetFromCommand(void* ctx){
     RedisModule_UnblockClient(csCtx->bc, csCtx);
 }
 
-static int MR_ClusterSetUnblock(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-    ClusterSetCtx* csCtx = RedisModule_GetBlockedClientPrivateData(ctx);
-    const char* errReply = csCtx->errReply;
+/* Frees the ClusterSetCtx. Registered as the block-client free_privdata callback so the
+ * context is released whenever the blocked client is destroyed - including when the client
+ * is torn down (e.g. on shutdown) without the reply callback ever running, which otherwise
+ * leaks the ClusterSetCtx and its held argv. Mirrors MR_ClusterInnerCommunicationMsgFreePD. */
+static void MR_ClusterSetFreePD(RedisModuleCtx* ctx, void* pd) {
+    ClusterSetCtx* csCtx = pd;
     for(size_t i = 0 ; i < csCtx->argc ; ++i){
         RedisModule_FreeString(NULL, csCtx->argv[i]);
     }
     MR_FREE(csCtx->argv);
     MR_FREE(csCtx);
-    if (errReply) {
-        RedisModule_ReplyWithError(ctx, errReply);
+}
+
+static int MR_ClusterSetUnblock(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    // csCtx is freed by MR_ClusterSetFreePD (the block-client free_privdata callback), not here.
+    ClusterSetCtx* csCtx = RedisModule_GetBlockedClientPrivateData(ctx);
+    if (csCtx->errReply) {
+        RedisModule_ReplyWithError(ctx, csCtx->errReply);
     } else {
         RedisModule_ReplyWithSimpleString(ctx, "OK");
     }
@@ -1414,7 +1422,7 @@ static int MR_ClusterSetUnblock(RedisModuleCtx *ctx, RedisModuleString **argv, i
 
 static int MR_ClusterSetInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool force){
     ClusterSetCtx* csCtx = MR_ALLOC(sizeof(*csCtx));
-    csCtx->bc = RedisModule_BlockClient(ctx, MR_ClusterSetUnblock, NULL, NULL, 0);
+    csCtx->bc = RedisModule_BlockClient(ctx, MR_ClusterSetUnblock, NULL, MR_ClusterSetFreePD, 0);
     csCtx->argv = argv;
     csCtx->argc = argc;
     csCtx->force = force;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1618,6 +1618,7 @@ static void MR_ClusterInfo(void* pd) {
     RedisModuleCtx* ctx = RedisModule_GetThreadSafeContext(bc);
     if(!clusterCtx.CurrCluster){
         RedisModule_ReplyWithStringBuffer(ctx, NO_CLUSTER_MODE_REPLY, strlen(NO_CLUSTER_MODE_REPLY));
+        RedisModule_FreeThreadSafeContext(ctx);
         RedisModule_UnblockClient(bc, NULL);
         return;
     }


### PR DESCRIPTION
Two independent memory-safety defects in the MOD-16382 topology-change command paths, both caught by the `linux-sanitizer / x64-jammy-oss_cluster` leg on [RedisTimeSeries#2116](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2116) once topology auto-refresh + eager-connect exercise these paths under churn. Verified end-to-end: with these two fixes (on top of the exec-leak fix #108 and eager-connect), the oss_cluster sanitizer leg goes fully green (all 5 sanitizer legs pass, 0 ASAN/LSan reports).

Both are in cluster.c and orthogonal to the Execution-leak fix (#108); kept in one PR since they're the same subsystem.

## 1. `MR_ClusterHello` use-after-free

`MR_ClusterHello` (the `timeseries.HELLO` handler) ran on the **main/command thread** and read `clusterCtx.CurrCluster->runId` synchronously. But `clusterCtx.CurrCluster` is owned by the **event-loop thread**, which frees and swaps it in `MR_UpdateClusterTopologyIfNeeded -> MR_ClusterFree -> FreeCluster` on every topology change. The main-thread read races that free:

```
READ  ... in MR_ClusterHello cluster.c
freed by (timeseries-el) ... FreeCluster <- MR_ClusterFree <- MR_UpdateClusterTopologyIfNeeded
allocated ... BuildCluster <- MR_UpdateClusterTopology
```

Every sibling command already defers to the event loop (`MR_ClusterInfo`, `MR_ClusterRefresh`, `MR_ClusterSet`); `HELLO` was the only one reading `CurrCluster` synchronously. **Fix:** block the client and read/reply from an `MR_EventLoopAddTask` task, so the read is serialized with the free/swap on the event-loop thread. Latent for a long time (pre-MOD-16382 `CurrCluster` was never freed at runtime); exposed by MOD-16951 eager-connect firing a HELLO storm right at topology-install time.

## 2. `ClusterSetCtx` leak

`MR_ClusterSetInternal` (the `CLUSTERSET` / `CLUSTERSETFROMSHARD` path) allocated a `ClusterSetCtx` (+ a held `argv` copy) and freed it only in the reply callback `MR_ClusterSetUnblock`, passing **NULL** for `RedisModule_BlockClient`'s `free_privdata`. When the blocked client is destroyed without the reply callback running (e.g. at shutdown with a `CLUSTERSETFROMSHARD` in flight), the context and its argv leak — LeakSanitizer reports ~40-90 bytes per instance rooted at `MR_ClusterSetInternal` / `MR_ClusterSetFromShard`.

**Fix:** move the free into a `free_privdata` callback (`MR_ClusterSetFreePD`) so the context is released whenever the blocked client is destroyed, and make the reply callback reply-only — exactly one free, no double-free. Mirrors the existing `MR_ClusterInnerCommunicationMsgFreePD` pattern.

## Testing
- `make -C src/` builds clean.
- oss_cluster sanitizer leg green end-to-end on RTS#2116 (integration branch `tom.gabsow/rts2116-eagerconnect-leakfix`): `496 tests, 0 failures` + `3 tests, 0 failures`, 0 LeakSanitizer/ASAN reports on any of the 5 sanitizer legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches cluster topology and blocked-client lifetimes where races and leaks showed up under sanitizer/OSS cluster churn; behavior change is threading serialization for HELLO, not new features.
> 
> **Overview**
> Fixes two memory-safety bugs in cluster topology command paths in `cluster.c`.
> 
> **`MR_ClusterHello` use-after-free:** The HELLO handler no longer reads `clusterCtx.CurrCluster->runId` on the command thread. It blocks the client and runs **`MR_ClusterHelloReply`** on the event loop (same pattern as `MR_ClusterInfo` / refresh), so reads of `CurrCluster` are serialized with topology free/swap on that thread.
> 
> **`ClusterSetCtx` leak:** **`MR_ClusterSetFreePD`** is registered as the `RedisModule_BlockClient` `free_privdata` callback so `ClusterSetCtx` and held `argv` strings are freed when the blocked client is destroyed without the reply callback (e.g. shutdown). **`MR_ClusterSetUnblock`** only sends the reply; freeing mirrors **`MR_ClusterInnerCommunicationMsgFreePD`**.
> 
> Also adds **`RedisModule_FreeThreadSafeContext`** on the early “no cluster” return path in **`MR_ClusterInfo`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64fbdcdc2c5d6c72b4f807d6f182b0c3bc660e24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->