### PR TITLE
MOD-16951 fix `checkTLS` condition with `tls-cluster` config

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -548,32 +548,10 @@ static int checkTLS(char** client_key, char** client_cert, char** ca_cert, char*
     char* tlsPort = NULL;
 
     clusterTls = getConfigValue(mr_staticCtx, "tls-cluster");
-    if (!clusterTls || strcmp(clusterTls, "yes")) {
-        /* MOD-16951: when the topology is built from the native cluster view
-         * (RedisModule_GetClusterNodeInfo -- used by the topology-change event,
-         * REFRESHCLUSTER and short-form CLUSTERSET; see MR_RefreshClusterData /
-         * BuildCluster), the peer port we dial is the PLAINTEXT node port whenever
-         * tls-cluster is off. So for those paths the inter-shard TLS decision must be
-         * gated strictly on tls-cluster: a bare tls-port (external TLS clients over an
-         * otherwise-plaintext bus) must NOT force TLS here, or we'd open a TLS handshake
-         * against a plaintext port -> the peer's RESP parser blocks on a reply that never
-         * comes and multi-shard commands (TS.MRANGE / TS.QUERYINDEX) hang until
-         * "execution max idle reached".
-         *
-         * Long-form CLUSTERSET is the exception: there the caller (e.g. the enterprise
-         * DMC) supplies explicit shard endpoints, which may be TLS ports, so it keeps the
-         * historical tls-port fallback. */
-        bool explicitEndpoints = clusterCtx.CurrCluster &&
-            IsLongFormClusterSet(clusterCtx.CurrCluster->clusterSetCommandSize);
-        if (!explicitEndpoints) {
-            ret = 0;
-            goto done;
-        }
-        tlsPort = getConfigValue(mr_staticCtx, "tls-port");
-        if (!tlsPort || !strcmp(tlsPort, "0")) {
-            ret = 0;
-            goto done;
-        }
+    bool clusterTlsEnabled = clusterTls && !strcmp(clusterTls, "yes");
+    if (!clusterTlsEnabled) {
+        ret = 0;
+        goto done;
     }
 
     *client_key = getConfigValue(mr_staticCtx, "tls-key-file");

--- a/tests/mr_test_module/Makefile
+++ b/tests/mr_test_module/Makefile
@@ -55,8 +55,8 @@ test: build
 test_ssl: build
 	bash ./generate_tests_cert.sh
 	DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh -t ./pytests/ --tls --tls-cert-file ./tests/tls/redis.crt --tls-key-file ./tests/tls/redis.key --tls-ca-cert-file ./tests/tls/ca.crt --tls-passphrase foobar
-	DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh -t ./pytests/ --env oss-cluster --shards-count 2 --tls --tls-cert-file ./tests/tls/redis.crt --tls-key-file ./tests/tls/redis.key --tls-ca-cert-file ./tests/tls/ca.crt --tls-passphrase foobar --oss-redis-args "--tls-cluster yes"
-	DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh -t ./pytests/ --env oss-cluster --shards-count 3 --tls --tls-cert-file ./tests/tls/redis.crt --tls-key-file ./tests/tls/redis.key --tls-ca-cert-file ./tests/tls/ca.crt --tls-passphrase foobar --oss-redis-args "--tls-cluster yes"
+	DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh -t ./pytests/ --env oss-cluster --shards-count 2 --tls --tls-cert-file ./tests/tls/redis.crt --tls-key-file ./tests/tls/redis.key --tls-ca-cert-file ./tests/tls/ca.crt --tls-passphrase foobar
+	DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh -t ./pytests/ --env oss-cluster --shards-count 3 --tls --tls-cert-file ./tests/tls/redis.crt --tls-key-file ./tests/tls/redis.key --tls-ca-cert-file ./tests/tls/ca.crt --tls-passphrase foobar
 
 test_valgrind: build
 	DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh -t ./pytests/ -V --vg-suppressions ./leakcheck.supp

--- a/tests/mr_test_module/Makefile
+++ b/tests/mr_test_module/Makefile
@@ -55,8 +55,8 @@ test: build
 test_ssl: build
 	bash ./generate_tests_cert.sh
 	DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh -t ./pytests/ --tls --tls-cert-file ./tests/tls/redis.crt --tls-key-file ./tests/tls/redis.key --tls-ca-cert-file ./tests/tls/ca.crt --tls-passphrase foobar
-	DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh -t ./pytests/ --env oss-cluster --shards-count 2 --tls --tls-cert-file ./tests/tls/redis.crt --tls-key-file ./tests/tls/redis.key --tls-ca-cert-file ./tests/tls/ca.crt --tls-passphrase foobar
-	DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh -t ./pytests/ --env oss-cluster --shards-count 3 --tls --tls-cert-file ./tests/tls/redis.crt --tls-key-file ./tests/tls/redis.key --tls-ca-cert-file ./tests/tls/ca.crt --tls-passphrase foobar
+	DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh -t ./pytests/ --env oss-cluster --shards-count 2 --tls --tls-cert-file ./tests/tls/redis.crt --tls-key-file ./tests/tls/redis.key --tls-ca-cert-file ./tests/tls/ca.crt --tls-passphrase foobar --oss-redis-args "--tls-cluster yes"
+	DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh -t ./pytests/ --env oss-cluster --shards-count 3 --tls --tls-cert-file ./tests/tls/redis.crt --tls-key-file ./tests/tls/redis.key --tls-ca-cert-file ./tests/tls/ca.crt --tls-passphrase foobar --oss-redis-args "--tls-cluster yes"
 
 test_valgrind: build
 	DEBUG=$(DEBUG_RUN) $(HERE)/pytests/run_tests.sh -t ./pytests/ -V --vg-suppressions ./leakcheck.supp

--- a/tests/mr_test_module/pytests/common.py
+++ b/tests/mr_test_module/pytests/common.py
@@ -167,6 +167,10 @@ def MRTestDecorator(redisConfigFileContent=None, moduleArgs=None, skipTest=False
             envArgs['moduleArgs'] = moduleArgs or defaultModuleArgs
             envArgs['redisConfigFile'] = create_config_file(redisConfigFileContent) if redisConfigFileContent else None
             env = Env(**envArgs)
+            if getattr(env, 'useTLS', False):
+                # checkTLS() in src/cluster.c gates inter-shard TLS strictly on
+                # tls-cluster; --tls alone (client-facing TLS) is not enough.
+                env.broadcast('CONFIG', 'SET', 'tls-cluster', 'yes')
             conn = getConnectionByEnv(env)
             if skipOnSingleShard:
                 if env.shardsCount == 1:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes when LibMR opens TLS between shards and drops the long-form CLUSTERSET `tls-port` fallback, which can affect enterprise topologies that relied on explicit TLS endpoints without `tls-cluster`.
> 
> **Overview**
> **Inter-shard TLS** in `checkTLS()` is now enabled only when Redis `tls-cluster` is `yes`. The previous logic that could still turn on TLS via `tls-port` (and a long-form `CLUSTERSET` exception) is removed, so client-facing TLS alone no longer triggers a TLS handshake on the plaintext cluster bus port—avoiding hangs on multi-shard commands (e.g. TS.MRANGE) when peers never reply.
> 
> TLS test envs now **`CONFIG SET tls-cluster yes`** in `MRTestDecorator` when `useTLS` is set, matching that gate so shard connections exercise the same path as production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5049abd1ee75a63b4e1256ed60e3ed5168222cfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->