### PR TITLE
MOD-17016 Detect Enterprise-managed native clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,13 @@ else
 	VENV_PYTHON := $(shell test -x $(CURDIR)/.venv/bin/python && echo $(CURDIR)/.venv/bin/python || echo python3)
 endif
 
-run_tests:
+test_runtime_detection:
+	$(CC) -std=c99 -Wall -Wextra -Werror -pedantic \
+		tests/cluster_runtime_test.c -o tests/cluster_runtime_test
+	./tests/cluster_runtime_test
+	$(RM) tests/cluster_runtime_test
+
+run_tests: test_runtime_detection
 	LIBCLANG_PATH="$(LIBCLANG_PATH)" OPENSSL_PREFIX="$(OPENSSL_PREFIX)" PKG_CONFIG_PATH="$(PKG_CONFIG_PATH)" PYTHON="$(VENV_PYTHON)" make -C ./tests/mr_test_module/ test
 
 run_tests_valgrind:
@@ -35,4 +41,4 @@ run_tests_ssl:
 
 clean_libmr:
 	make clean -C src/
-
+	$(RM) tests/cluster_runtime_test

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -12,6 +12,7 @@
 #include "common.h"
 #include "mr.h"
 #include "cluster.h"
+#include "cluster_runtime.h"
 #include "event_loop.h"
 #include "utils/arr_rm_alloc.h"
 #include "utils/buffer.h"
@@ -1757,6 +1758,42 @@ static void MR_NetworkTest(RedisModuleCtx *ctx, const char *sender_id, uint8_t t
     RedisModule_Log(ctx, "notice", "got a nextwork test msg");
 }
 
+static bool ConfigValueEquals(RedisModuleCtx *ctx, const char *name,
+                              const char *expected, bool *resolved) {
+    *resolved = false;
+    RedisModuleCallReply *reply = RedisModule_Call(ctx, "config", "cc", "get", name);
+    if (!reply) {
+        return false;
+    }
+
+    /* CONFIG GET replies as a flat array in RESP2 and as a map in RESP3. */
+    int replyType = RedisModule_CallReplyType(reply);
+    RedisModuleCallReply *value = NULL;
+    if (replyType == REDISMODULE_REPLY_ARRAY &&
+        RedisModule_CallReplyLength(reply) >= 2) {
+        value = RedisModule_CallReplyArrayElement(reply, 1);
+    } else if (replyType == REDISMODULE_REPLY_MAP &&
+               RedisModule_CallReplyMapElement &&
+               RedisModule_CallReplyLength(reply) >= 1) {
+        RedisModule_CallReplyMapElement(reply, 0, NULL, &value);
+    }
+
+    bool matches = false;
+    if (value && RedisModule_CallReplyType(value) == REDISMODULE_REPLY_STRING) {
+        size_t valueLen = 0;
+        const char *valueStr = RedisModule_CallReplyStringPtr(value, &valueLen);
+        if (valueStr) {
+            size_t expectedLen = strlen(expected);
+            *resolved = true;
+            matches = valueLen == expectedLen &&
+                      memcmp(valueStr, expected, expectedLen) == 0;
+        }
+    }
+
+    RedisModule_FreeCallReply(reply);
+    return matches;
+}
+
 int MR_ClusterInit(RedisModuleCtx* rctx, char *password) {
     clusterCtx.CurrCluster = NULL;
     clusterCtx.callbacks = array_new(MR_ClusterMessageReceiver, 10);
@@ -1771,36 +1808,9 @@ int MR_ClusterInit(RedisModuleCtx* rctx, char *password) {
     /* Note: RedisModule_GetContextFlags() does NOT report
      * REDISMODULE_CTX_FLAGS_CLUSTER yet at module-load time, so read the
      * cluster-enabled config directly to learn the runtime mode. */
-    bool ossClusterRuntime = false;
     bool ceResolved = false;
-    RedisModuleCallReply *ceReply = RedisModule_Call(rctx, "config", "cc", "get", "cluster-enabled");
-    if (ceReply) {
-        /* CONFIG GET replies as a flat array in RESP2 and as a map in RESP3.
-         * The module ctx defaults to RESP2, but handle both shapes so a future
-         * RESP3 default can't silently break detection and misclassify an
-         * OSS-cluster shard as enterprise. */
-        int ceType = RedisModule_CallReplyType(ceReply);
-        RedisModuleCallReply *val = NULL;
-        if (ceType == REDISMODULE_REPLY_ARRAY && RedisModule_CallReplyLength(ceReply) >= 2) {
-            val = RedisModule_CallReplyArrayElement(ceReply, 1);
-        } else if (ceType == REDISMODULE_REPLY_MAP && RedisModule_CallReplyMapElement &&
-                   RedisModule_CallReplyLength(ceReply) >= 1) {
-            RedisModule_CallReplyMapElement(ceReply, 0, NULL, &val);
-        }
-        if (val && RedisModule_CallReplyType(val) == REDISMODULE_REPLY_STRING) {
-            size_t vlen = 0;
-            const char *vstr = RedisModule_CallReplyStringPtr(val, &vlen);
-            if (vstr) {
-                ceResolved = true;
-                /* CONFIG GET returns the canonical lowercase "yes"/"no" (Redis
-                 * spec), so a case-sensitive compare of exactly 3 bytes is safe. */
-                if (vlen == 3 && memcmp(vstr, "yes", 3) == 0) {
-                    ossClusterRuntime = true;
-                }
-            }
-        }
-        RedisModule_FreeCallReply(ceReply);
-    }
+    bool clusterEnabled =
+        ConfigValueEquals(rctx, "cluster-enabled", "yes", &ceResolved);
     if (!ceResolved) {
         /* CONFIG GET cluster-enabled should always succeed; an error, an
          * unexpected reply shape, or an empty value leaves the runtime cluster
@@ -1819,17 +1829,30 @@ int MR_ClusterInit(RedisModuleCtx* rctx, char *password) {
      * present-but-unparseable rlec_version would otherwise read as OSS.
      *
      * Treat the shard as enterprise only when rlec_version is present AND we
-     * are not in OSS cluster mode. This is the load-bearing decision of the
-     * PR: it unblocks an enterprise binary running as an OSS cluster (e.g. the
-     * env0 testing setup), which must take the OSS path (internal-secret AUTH,
-     * no _proxy-filtered command flags) rather than the enterprise path. */
-    if (MR_RlecVersionPresent && !ossClusterRuntime) {
+     * are not in native cluster mode, except for an Enterprise-managed native
+     * cluster. In ASM, ClusterPlugin is loaded before data modules and registers
+     * an immutable clusterplugin.cluster-topology-uri config. ClusterPlugin
+     * refuses to load while the URI is "unset", so a non-default value narrowly
+     * distinguishes ASM from an enterprise binary running as a standalone OSS
+     * cluster (e.g. the env0 testing setup). */
+    bool managedNativeCluster = false;
+    if (MR_RlecVersionPresent && clusterEnabled) {
+        bool topologyUriResolved = false;
+        bool topologyUriUnset =
+            ConfigValueEquals(rctx, "clusterplugin.cluster-topology-uri",
+                              "unset", &topologyUriResolved);
+        managedNativeCluster = topologyUriResolved && !topologyUriUnset;
+    }
+    if (MR_IsEnterpriseRuntime(MR_RlecVersionPresent, clusterEnabled,
+                               managedNativeCluster)) {
         clusterCtx.isOss = false;
     }
 
-    RedisModule_Log(rctx, "notice", "Detected redis %s (cluster-enabled=%s)",
+    RedisModule_Log(rctx, "notice",
+                    "Detected redis %s (cluster-enabled=%s, managed-native-cluster=%s)",
                     clusterCtx.isOss ? "oss" : "enterprise",
-                    ossClusterRuntime ? "yes" : "no");
+                    clusterEnabled ? "yes" : "no",
+                    managedNativeCluster ? "yes" : "no");
 
     const char *command_flags = "readonly deny-script";
     if (!clusterCtx.isOss) {

--- a/src/cluster_runtime.h
+++ b/src/cluster_runtime.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of (a) the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+
+#ifndef LIBMR_CLUSTER_RUNTIME_H
+#define LIBMR_CLUSTER_RUNTIME_H
+
+#include <stdbool.h>
+
+static inline bool MR_IsEnterpriseRuntime(bool rlecVersionPresent,
+                                          bool clusterEnabled,
+                                          bool managedNativeCluster) {
+    return rlecVersionPresent &&
+           (!clusterEnabled || managedNativeCluster);
+}
+
+#endif

--- a/tests/cluster_runtime_test.c
+++ b/tests/cluster_runtime_test.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of (a) the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+
+#include "../src/cluster_runtime.h"
+
+#include <assert.h>
+
+int main(void) {
+    /* OSS binaries always use the OSS transport. */
+    assert(!MR_IsEnterpriseRuntime(false, false, false));
+    assert(!MR_IsEnterpriseRuntime(false, true, false));
+    assert(!MR_IsEnterpriseRuntime(false, true, true));
+
+    /* Classic Enterprise uses the proxy-filtered transport. */
+    assert(MR_IsEnterpriseRuntime(true, false, false));
+
+    /* Preserve the standalone Enterprise-binary OSS-cluster test setup. */
+    assert(!MR_IsEnterpriseRuntime(true, true, false));
+
+    /* Enterprise-managed native clusters use the proxy-filtered transport. */
+    assert(MR_IsEnterpriseRuntime(true, true, true));
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Detect Enterprise-managed native clusters from the configured `clusterplugin.cluster-topology-uri` module config.
- Preserve the behavior from #98 for a private Redis binary running an unmanaged OSS cluster.
- Select the Enterprise `_proxy-filtered` transport in ASM without exposing LibMR internal commands.
- Add a truth-table regression test for OSS, classic Enterprise, unmanaged native cluster, and ASM.

## Root cause

#98 treated every `cluster-enabled=yes` runtime as OSS. ASM also runs Redis with native clustering enabled, but loads ClusterPlugin with a configured topology URI. LibMR therefore selected its OSS HELLO/internal-secret transport instead of the Enterprise proxy-filtered transport. Peers rejected the internal HELLO command and fan-out operations timed out.

Both MOD-17016 support packages use LibMR `a37b672`, which contains #98 but predates #105. Their logs show the communication failure before scale begins, so this issue is independent of the topology repointing change in #105.

## Why this marker

In ASM, ClusterPlugin loads before data modules and registers `clusterplugin.cluster-topology-uri` as immutable. ClusterPlugin refuses to initialize while the value remains its default, `unset`. A resolved, non-default value therefore narrowly distinguishes an Enterprise-managed native cluster from the unmanaged private-binary OSS-cluster test setup.

The URI itself is never logged.

## Testing

- `make test_runtime_detection`
- `make run_tests` with Redis 7.4.10: standalone and 1-, 2-, and 3-shard OSS-cluster environments; zero failures in all four environments
- Private Enterprise Redis integration validation:
  - `cluster-enabled=yes` without ClusterPlugin selects OSS transport
  - `cluster-enabled=yes` with configured ClusterPlugin selects Enterprise transport and loads successfully with `_proxy-filtered` commands

Related: https://redislabs.atlassian.net/browse/MOD-17016

Context: https://github.com/RedisGears/LibMR/pull/98, https://github.com/RedisGears/LibMR/pull/105

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster init transport selection for multi-shard fan-out; mis-detection would still cause HELLO/timeouts or wrong command visibility, though behavior is covered by a truth-table test and preserves the #98 unmanaged-cluster case.
> 
> **Overview**
> **Fixes LibMR choosing the wrong inter-shard transport** when Redis Enterprise runs with native clustering (ASM): it now treats that layout as Enterprise and uses `_proxy-filtered` commands instead of the OSS HELLO/internal-secret path that peers reject.
> 
> Runtime classification is centralized in `MR_IsEnterpriseRuntime()` (`cluster_runtime.h`). Enterprise mode applies when `rlec_version` is present and either clustering is off **or** the shard is an **Enterprise-managed native cluster**. The latter is inferred when `cluster-enabled` is `yes` and `clusterplugin.cluster-topology-uri` is set to something other than the default `unset` (ASM loads ClusterPlugin with a real topology URI). The prior #98 behavior is preserved for an Enterprise binary in an **unmanaged** OSS-style cluster test setup (`cluster-enabled=yes` without that URI).
> 
> `MR_ClusterInit` refactors CONFIG reads through a shared `ConfigValueEquals()` helper (RESP2 array and RESP3 map), logs `managed-native-cluster`, and wires the decision into `clusterCtx.isOss` and command registration flags.
> 
> A small C truth-table test (`make test_runtime_detection`) is added and hooked into `run_tests`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64fb1f336357c9c9de0ee9bcd2dadcc8508fe15f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->