### PR TITLE
MOD-16382 Preserve topology on gated CLUSTERSET

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1287,6 +1287,9 @@ static int SetClusterDataShortForm(RedisModuleString** argv, int argc){
         RedisModule_Log(mr_staticCtx, "notice", "Got cluster set command (short form)");
     }
 
+    if(clusterCtx.CurrCluster)
+        MR_ClusterFree();
+
     // RedisModule_GetClusterNodeSlotRanges may be NULL when the host Redis
     // build does not export it (e.g. OSS Redis without the backport). Reject
     // the command with an error instead of crashing or silently no-op'ing, so
@@ -1337,6 +1340,9 @@ static void SetClusterDataLongForm(RedisModuleString** argv, int argc){
         RedisModule_Assert(!MR_TopologyEventSeen);  // Since no handler was registered for topology events
         RedisModule_Log(mr_staticCtx, "notice", "Got cluster set command (long form)");
     }
+
+    if(clusterCtx.CurrCluster)
+        MR_ClusterFree();
 
     clusterCtx.CurrCluster = MR_CALLOC(1, sizeof(*clusterCtx.CurrCluster));
     InitClusterData(clusterCtx.CurrCluster, argv, argc);
@@ -1401,9 +1407,6 @@ static void SetClusterDataLongForm(RedisModuleString** argv, int argc){
 }
 
 static int MR_SetClusterData(RedisModuleString** argv, int argc){
-    if(clusterCtx.CurrCluster)
-        MR_ClusterFree();
-
     if (IsLongFormClusterSet(argc)) {
         SetClusterDataLongForm(argv, argc);
         return REDISMODULE_OK;


### PR DESCRIPTION
## Problem

With topology events enabled, `MR_SetClusterData()` freed `CurrCluster` before the short- and long-form handlers checked `MR_TopologyEventSeen`. A gated `CLUSTERSET` therefore returned without rebuilding the topology, leaving `CurrCluster == NULL`.

## Fix

Move `MR_ClusterFree()` into both form handlers, immediately after their existing topology-events gate. Skipped commands now return before mutating the installed topology; processed commands retain the same free-and-rebuild behavior.

## Validation

- `make -j4`
- `make -C tests/mr_test_module build` (Rust stable)
- Focused `test_network.py` run on a 3-shard OSS cluster: 15/18 passed; 3 setup failures because Redis 8.2 hid the test-only `MRTESTS.REFRESHCLUSTER` / `MRTESTS.FORCESHARDSCONNECTION` commands before the changed path was exercised.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster topology lifecycle during CLUSTERSET handling; wrong ordering could leave stale or missing cluster state, but the change is small and scoped to when free runs relative to skip paths.
> 
> **Overview**
> Fixes a **NULL `CurrCluster`** bug when topology events are enabled and a redundant **CLUSTERSET** is ignored after a topology event has already populated the cluster.
> 
> **`MR_ClusterFree()`** is no longer called at the start of **`MR_SetClusterData`** before dispatching to the short/long parsers. It now runs inside **`SetClusterDataShortForm`** and **`SetClusterDataLongForm`** only **after** the topology-event skip checks and **before** rebuilding topology, matching the pattern used in **`MR_RefreshClusterData`** so a skipped command does not tear down a valid event-built cluster.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3de5b979020f37eda4b275d1594c26d79f020aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->