### PR TITLE
MOD-16600 Serialize legacy topology replacement (#116) [8.8 backport]

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -892,9 +892,7 @@ static void MR_RefreshClusterData(){
     memcpy(clusterCtx.myId, clusterCtx.CurrCluster->myId, REDISMODULE_NODE_ID_LEN + 1);
     clusterCtx.CurrCluster->nodes = mr_dictCreate(&mr_dictTypeHeapStrings, NULL);
 
-    RedisModule_ThreadSafeContextLock(mr_staticCtx);
     RedisModuleCallReply *allSlotsReply = RedisModule_Call(mr_staticCtx, "cluster", "c", "slots");
-    RedisModule_ThreadSafeContextUnlock(mr_staticCtx);
 
     RedisModule_Assert(RedisModule_CallReplyType(allSlotsReply) == REDISMODULE_REPLY_ARRAY);
     for(size_t i = 0 ; i < RedisModule_CallReplyLength(allSlotsReply) ; ++i){
@@ -930,10 +928,7 @@ static void MR_RefreshClusterData(){
         // invoking `cluster slot` from RM_Call will always return the none tls port.
         // For for information refer to: https://github.com/redis/redis/pull/12233
         int port = 0;
-        RedisModule_ThreadSafeContextLock(mr_staticCtx);
         RedisModule_GetClusterNodeInfo(mr_staticCtx, nodeId, NULL, NULL, &port, NULL);
-        RedisModule_ThreadSafeContextUnlock(mr_staticCtx);
-
 
         Node* n = MR_GetNode(nodeId);
         if(!n){
@@ -1267,23 +1262,29 @@ static int MR_SetClusterData(RedisModuleString** argv, int argc){
     }
 }
 
-/* runs in the event loop so its safe to update cluster
- * topology here */
+/* Runs on the LibMR event loop. Hold the Redis lock across the complete
+ * free/rebuild sequence so the main thread cannot observe partial topology. */
 static void MR_ClusterRefreshFromCommand(void* ctx){
     RedisModuleBlockedClient* bc = ctx;
+    RedisModule_ThreadSafeContextLock(mr_staticCtx);
     MR_RefreshClusterData();
+    RedisModule_ThreadSafeContextUnlock(mr_staticCtx);
     RedisModuleCtx* rCtx = RedisModule_GetThreadSafeContext(bc);
     RedisModule_ReplyWithSimpleString(rCtx, "OK");
     RedisModule_FreeThreadSafeContext(rCtx);
     RedisModule_UnblockClient(bc, NULL);
 }
 
-/* runs in the event loop so its safe to update cluster
- * topology here */
+/* Runs on the LibMR event loop. Redis' main thread also reads clusterCtx while
+ * creating executions, so hold the Redis lock across the legacy free/rebuild
+ * sequence and do not expose its temporary one-shard state. */
 static void MR_ClusterSetFromCommand(void* ctx){
     ClusterSetCtx* csCtx = ctx;
     if (!clusterCtx.CurrCluster || csCtx->force) {
-        if (MR_SetClusterData(csCtx->argv, csCtx->argc) != REDISMODULE_OK) {
+        RedisModule_ThreadSafeContextLock(mr_staticCtx);
+        int status = MR_SetClusterData(csCtx->argv, csCtx->argc);
+        RedisModule_ThreadSafeContextUnlock(mr_staticCtx);
+        if (status != REDISMODULE_OK) {
             csCtx->errReply = CLUSTER_ERROR" Failed to set cluster topology";
         }
     }

--- a/tests/mr_test_module/pytests/test_network.py
+++ b/tests/mr_test_module/pytests/test_network.py
@@ -4,6 +4,7 @@ import gevent.queue
 import gevent.socket
 import time
 import socket
+import threading
 
 class Connection(object):
     def __init__(self, sock, bufsize=4096, underlying_sock=None):
@@ -294,6 +295,117 @@ def _is_ipv6_enabled():
 
 def _get_hosts():
     return ['localhost', '::0'] if _is_ipv6_enabled() else ['localhost']
+
+
+def _long_form_cluster_set_args(conn, repetitions):
+    """Repeat the installed ranges to make the real replacement window observable."""
+    info = conn.execute_command('MRTESTS.INFOCLUSTER')
+    my_id = info[1]
+    nodes = [dict(zip(node[::2], node[1::2])) for node in info[4]]
+    args = [
+        'HASHFUNC', 'CRC16',
+        'NUMSLOTS', '16384',
+        'MYID', my_id,
+        'RANGES', str(len(nodes) * repetitions),
+    ]
+    for _ in range(repetitions):
+        for node in nodes:
+            host = node['ip']
+            endpoint_host = '[%s]' % host if ':' in host else host
+            args.extend([
+                'SHARD', node['id'],
+                'SLOTRANGE', str(node['minHslot']), str(node['maxHslot']),
+                'ADDR', 'password@%s:%s' % (endpoint_host, node['port']),
+                'MASTER',
+            ])
+    return args
+
+
+@MRTestDecorator(skipOnSingleShard=True)
+def testInternalCommandDuringLongFormClusterSet(env, conn):
+    topology_conn = env.getConnection(shardId=1)
+    internal_command_conn = env.getConnection(shardId=1)
+    promote_internal_client_if_supported(conn=topology_conn)
+
+    # MR_ClusterFree() sets clusterSize to one before SetClusterDataLongForm()
+    # installs the replacement. Repeating valid ranges widens that real
+    # replacement window without adding a test-only production hook.
+    cluster_set_args = _long_form_cluster_set_args(topology_conn, 2048)
+    topology_error = []
+
+    def replace_topology():
+        try:
+            topology_conn.execute_command('MRTESTS.CLUSTERSET', *cluster_set_args)
+            topology_conn.execute_command('MRTESTS.FORCESHARDSCONNECTION')
+        except Exception as error:
+            topology_error.append(error)
+
+    topology_thread = threading.Thread(target=replace_topology)
+    topology_thread.start()
+    time.sleep(0.01)
+
+    result = internal_command_conn.execute_command('lmrtest.internalcommand')
+    topology_thread.join(timeout=10)
+
+    env.assertFalse(topology_thread.is_alive(), message='CLUSTERSET did not finish')
+    env.assertEqual(topology_error, [])
+    env.assertEqual(result, 'OK')
+
+    # Execution start is asynchronous. On the buggy code it is marked local
+    # during the replacement window and reaches the worker assertion.
+    time.sleep(0.5)
+    env.assertTrue(internal_command_conn.ping())
+
+    # Restore the native topology so later tests never see repeated ranges.
+    env.broadcast('MRTESTS.REFRESHCLUSTER')
+
+
+@MRTestDecorator(skipOnSingleShard=True)
+def testInternalCommandDuringClusterRefresh(env, conn):
+    refresh_conn = env.getConnection(shardId=1)
+    internal_command_conn = env.getConnection(shardId=1)
+    start = threading.Barrier(3)
+    errors = []
+
+    def refresh_topology():
+        try:
+            start.wait()
+            # Repetition makes the real free/rebuild window deterministic
+            # without introducing a test-only delay in production code.
+            for _ in range(50):
+                refresh_conn.execute_command('MRTESTS.REFRESHCLUSTER')
+        except Exception as error:
+            errors.append(error)
+
+    def run_internal_commands():
+        try:
+            start.wait()
+            for _ in range(500):
+                internal_command_conn.execute_command('lmrtest.internalcommand')
+        except Exception as error:
+            errors.append(error)
+
+    refresh_thread = threading.Thread(target=refresh_topology)
+    internal_command_thread = threading.Thread(target=run_internal_commands)
+    refresh_thread.start()
+    internal_command_thread.start()
+    start.wait()
+
+    refresh_thread.join(timeout=20)
+    internal_command_thread.join(timeout=20)
+
+    env.assertFalse(refresh_thread.is_alive(), message='REFRESHCLUSTER did not finish')
+    env.assertFalse(internal_command_thread.is_alive(), message='internal commands did not finish')
+    env.assertEqual(errors, [])
+
+    # Execution start is asynchronous. A command classified from the temporary
+    # one-shard refresh state reaches the worker assertion after its reply.
+    time.sleep(0.5)
+    env.assertTrue(internal_command_conn.ping())
+
+    # Verify that the final refreshed topology can still run distributed work.
+    env.expect('lmrtest.readerror').equal([0, env.shardsCount])
+
 
 @MRTestDecorator(skipOnCluster=True)
 def testMessageIdCorrectness(env, conn):
@@ -743,4 +855,3 @@ def testSendMultiRangePerNodeTopology(env, conn):
 
             res = env.cmd(*cmd)
             assert res == 'OK'
-

--- a/tests/mr_test_module/src/lib.rs
+++ b/tests/mr_test_module/src/lib.rs
@@ -12,7 +12,7 @@ use mr::redis_module;
 use redis_module::redisraw::bindings::{
     RedisModuleCtx, RedisModuleKey, RedisModuleScanCursor, RedisModuleString,
     RedisModule_GetDetachedThreadSafeContext, RedisModule_Scan, RedisModule_ScanCursorCreate,
-    RedisModule_ScanCursorDestroy, RedisModule_ThreadSafeContextLock,
+    RedisModule_ScanCursorDestroy, RedisModule_ReplyWithLongLong, RedisModule_ThreadSafeContextLock,
     RedisModule_ThreadSafeContextUnlock,
 };
 
@@ -27,15 +27,24 @@ use mr::libmr::{
     reader::Reader, record::Record, remote_task::run_on_all_shards, remote_task::run_on_key,
     remote_task::RemoteTask, RustMRError,
 };
+use mr::libmr_c_raw::bindings::{
+    ExecutionCtx, InternalCommandCallbacks, MRError, MRObjectType, MRRecordType, Record as RawRecord,
+    RedisModuleCtx as MRRedisModuleCtx,
+    MR_CreateEmptyExecutionBuilder, MR_CreateExecution, MR_ExecutionBuilderInternalCommand,
+    MR_ExecutionSetMaxIdle, MR_ExecutionSetOnDoneHandler, MR_FreeExecution,
+    MR_FreeExecutionBuilder, MR_RegisterInternalCommand, MR_RegisterRecord, MR_Run,
+};
 use serde::{Deserialize, Serialize};
 
-use std::os::raw::c_void;
+use std::os::raw::{c_char, c_void};
+use std::ptr;
 
 use std::{thread, time};
 
 use mr_derive::BaseObject;
 
 static mut DETACHED_CTX: *mut RedisModuleCtx = std::ptr::null_mut();
+static mut INTERNAL_COMMAND_RECORD_TYPE: *mut MRRecordType = ptr::null_mut();
 
 fn get_redis_ctx() -> *mut RedisModuleCtx {
     unsafe { DETACHED_CTX }
@@ -58,6 +67,60 @@ fn ctx_unlock() {
     unsafe {
         RedisModule_ThreadSafeContextUnlock.unwrap()(inner);
     }
+}
+
+#[repr(C)]
+struct InternalCommandRecord {
+    base: RawRecord,
+}
+
+unsafe extern "C" fn internal_command_record_free(record: *mut c_void) {
+    drop(Box::from_raw(record as *mut InternalCommandRecord));
+}
+
+unsafe extern "C" fn internal_command(ctx: *mut MRRedisModuleCtx, _args: *mut c_void) {
+    RedisModule_ReplyWithLongLong.unwrap()(ctx.cast(), 1);
+}
+
+unsafe extern "C" fn internal_command_reply_parser(
+    _reply: *const mr::libmr_c_raw::bindings::redisReply,
+) -> *mut RawRecord {
+    let record = Box::new(InternalCommandRecord {
+        base: RawRecord {
+            recordType: INTERNAL_COMMAND_RECORD_TYPE,
+        },
+    });
+    Box::into_raw(record) as *mut RawRecord
+}
+
+unsafe extern "C" fn internal_command_done(_ectx: *mut ExecutionCtx, _pd: *mut c_void) {}
+
+fn lmr_internal_command(_ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
+    let builder = unsafe { MR_CreateEmptyExecutionBuilder() };
+    unsafe {
+        MR_ExecutionBuilderInternalCommand(
+            builder,
+            b"LMRTEST.INTERNAL\0".as_ptr() as *const c_char,
+            ptr::null_mut(),
+        );
+    }
+
+    let mut err: *mut MRError = ptr::null_mut();
+    let execution = unsafe { MR_CreateExecution(builder, &mut err) };
+    unsafe { MR_FreeExecutionBuilder(builder) };
+    if !err.is_null() {
+        return Err(RedisError::Str(
+            "failed creating internal command execution",
+        ));
+    }
+
+    unsafe {
+        MR_ExecutionSetMaxIdle(execution, 100);
+        MR_ExecutionSetOnDoneHandler(execution, Some(internal_command_done), ptr::null_mut());
+        MR_Run(execution);
+        MR_FreeExecution(execution);
+    }
+    Ok(RedisValue::SimpleStringStatic("OK"))
 }
 
 fn strin_record_new(s: String) -> StringRecord {
@@ -864,6 +927,31 @@ fn init_func(ctx: &Context, args: &[RedisString]) -> Status {
     mr_init(ctx, 5, pass.as_deref());
 
     KeysReader::register();
+    unsafe {
+        INTERNAL_COMMAND_RECORD_TYPE = Box::into_raw(Box::new(MRRecordType {
+            type_: MRObjectType {
+                type_: b"InternalCommandRecord\0".as_ptr() as *mut c_char,
+                id: 0,
+                free: Some(internal_command_record_free),
+                dup: None,
+                serialize: None,
+                deserialize: None,
+                tostring: None,
+            },
+            sendReply: None,
+            hashTag: None,
+        }));
+        MR_RegisterRecord(INTERNAL_COMMAND_RECORD_TYPE);
+        let callbacks = Box::into_raw(Box::new(InternalCommandCallbacks {
+            command: Some(internal_command),
+            replyParser: Some(internal_command_reply_parser),
+        }));
+        MR_RegisterInternalCommand(
+            b"LMRTEST.INTERNAL\0".as_ptr() as *const c_char,
+            callbacks,
+            ptr::null_mut(),
+        );
+    }
     Status::Ok
 }
 
@@ -888,5 +976,6 @@ redis_module! {
         ["lmrtest.accumulatererror", lmr_accumulate_error, "readonly", 0,0,0, AclCategory::None],
         ["lmrtest.readerror", lmr_read_error, "readonly", 0,0,0, AclCategory::None],
         ["lmrtest.unevenwork", lmr_uneven_work, "readonly", 0,0,0, AclCategory::None],
+        ["lmrtest.internalcommand", lmr_internal_command, "readonly", 0,0,0, AclCategory::None],
     ],
 }


### PR DESCRIPTION
## What

Clean cherry-pick of `25fe7a3` ("MOD-16600 Serialize legacy topology replacement", #116) onto `a37b672` — the LibMR commit pinned by RedisTimeSeries **8.8.x, 8.6 and 8.4**. No conflicts, and it brings its own regression coverage (`tests/mr_test_module`).

Base branch `8.8` is new: it is just `a37b672`, i.e. exactly what RTS 8.8 pins today, so this PR's diff is only #116. Happy to rename it (`rts-8.8`, `8.8-maintenance`, …) or drop it if the team would rather carry 8.8 backports differently — I created it because a reviewable PR needs a base and RTS pins a bare commit.

## Why 8.8 needs it

The assertion #116 prevents is **still reproducing on the RE8.8 nightly**. Build `100.0.20-7660` (2026-08-05), released TS `80802`, shard `redis-119`:

```
21:22:23.033  <timeseries> cluster topology changed        (x5 within 4ms)
21:22:23.037  <timeseries> Got cluster set command (long form)
21:22:23.037  === REDIS BUG REPORT START
21:22:23.037  # ==> /workspace/deps/LibMR/src/mr.c:939 'false' is not true
```

Long-form `CLUSTERSET` → `MR_SetClusterData` → `MR_ClusterFree()` transiently reports a one-shard topology → a concurrent execution takes `ExecutionFlag_Local` → its `StepType_InternalCommand` reaches the worker path → assert. Holding the Redis lock across the free/rebuild stops that state ever being observable.

master has carried this since 2026-07-26, but RTS 8.8 / 8.6 / 8.4 all pin `a37b672`, which predates it. So **MOD-16600 currently sits in *Awaiting Verification* against a lane that structurally cannot verify it** — the RE8.8 nightly has never run the fix.

## What this does not fix

The same support packages still show the MOD-15896 Enterprise/OSS misdetection: `Detected redis oss (cluster-enabled=yes)` on the ASM shards (×14 and ×24 in the two packages, versus ×180 correct `enterprise (cluster-enabled=no)` on the non-cluster DBs). On one shard that produced 1309 rejected `timeseries.HELLO`, 722 `message was not sent because status is not connected`, and 97 `execution max idle reached`.

That is a separate defect and it is unfixed on every line. So this backport should stop the crash but is not expected to make the ASM scale-under-traffic scenario pass on its own — same caveat recorded on MOD-16600 when #116 was opened.

## Verification

- `git cherry-pick` of `25fe7a3` onto `a37b672` applies with no conflicts; the resulting diff is byte-identical to #116's (`src/cluster.c` 21 lines, plus its tests).
- Behaviour is #116's, already reviewed and merged on master; nothing new is introduced here.
- Not run on a live Enterprise cluster — the acceptance test is the unchanged RE8.8 ASM nightly once RTS 8.8 bumps `deps/LibMR` to this commit.

## Follow-up

RTS-side pin bumps on `8.8` (and 8.6 / 8.4 if wanted) are the second half; I'll open those once this has a merge commit to point at.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes synchronization around cluster topology updates on a path tied to production crashes; scope is limited to lock placement and test coverage, not new topology logic.
> 
> **Overview**
> Fixes a race where **long-form `CLUSTERSET`** and **`REFRESHCLUSTER`** could leave `clusterCtx` in a transient one-shard state (`MR_ClusterFree()` sets `clusterSize` to 1) while the main thread still starts executions. Concurrent internal-command work could then be classified as local and hit an assertion in `mr.c`.
> 
> **Production change (`cluster.c`):** `MR_ClusterRefreshFromCommand` and `MR_ClusterSetFromCommand` now take `RedisModule_ThreadSafeContextLock` for the full `MR_RefreshClusterData` / `MR_SetClusterData` sequence (including the legacy free-then-rebuild path). Narrow locks around `cluster slots` / `GetClusterNodeInfo` inside refresh were removed so locking is owned at the event-loop handler level.
> 
> **Tests:** The `lmrtest` module gains `lmrtest.internalcommand` and a registered internal command so executions exercise the same routing path as production. New multi-shard tests overlap heavy `CLUSTERSET` or repeated `REFRESHCLUSTER` with internal commands to catch the bug without test-only delays in core code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2de069c91acadf97d4f835cb68724b77772a9efb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->