### PR TITLE
Keep MR_Init backward compatible so one master serves every RTS line

### DIFF
--- a/rust_api/libmr/mod.rs
+++ b/rust_api/libmr/mod.rs
@@ -9,7 +9,7 @@
 //! This module provides with the Map-Reduce operations supported.
 
 use crate::libmr_c_raw::bindings::{
-    MRRecordType, MR_CalculateSlot, MR_ClusterIsInClusterMode, MR_Init, MR_IsMySlot, RedisModuleCtx,
+    MRRecordType, MR_CalculateSlot, MR_ClusterIsInClusterMode, MR_InitWithTopologyEvents, MR_IsMySlot, RedisModuleCtx,
 };
 use redis_module::Context;
 
@@ -43,7 +43,7 @@ pub type RustMRError = String;
 pub fn mr_init(ctx: &Context, num_threads: usize, password: Option<&str>, topology_events: bool) {
     let password = password.map(|v| CString::new(v).unwrap());
     unsafe {
-        MR_Init(
+        MR_InitWithTopologyEvents(
             ctx.ctx as *mut RedisModuleCtx,
             num_threads,
             password

--- a/src/mr.c
+++ b/src/mr.c
@@ -1621,7 +1621,11 @@ static void MR_GetRedisVersion() {
     RedisModule_FreeCallReply(reply);
 }
 
-int MR_Init(RedisModuleCtx* ctx, size_t numThreads, char *password, bool topologyEvents) {
+int MR_Init(RedisModuleCtx* ctx, size_t numThreads, char *password) {
+    return MR_InitWithTopologyEvents(ctx, numThreads, password, false);
+}
+
+int MR_InitWithTopologyEvents(RedisModuleCtx* ctx, size_t numThreads, char *password, bool topologyEvents) {
     mr_staticCtx = RedisModule_GetDetachedThreadSafeContext(ctx);
     MR_GetRedisVersion();
 

--- a/src/mr.h
+++ b/src/mr.h
@@ -188,8 +188,17 @@ LIBMR_API void MR_FreeExecution(Execution* e);
  */
 LIBMR_API void MR_UpdateClusterTopology();
 
-/* Initialize mr library */
-LIBMR_API int MR_Init(struct RedisModuleCtx* ctx, size_t numThreads, char *password, bool topologyEvents);
+/* Initialize mr library.
+ * Pass topologyEvents=true only if the consumer registers a topology-change handler and calls
+ * MR_UpdateClusterTopology() from it; otherwise the topology-event paths stay inert and the
+ * cluster is configured by CLUSTERSET / REFRESHCLUSTER as before. */
+LIBMR_API int MR_InitWithTopologyEvents(struct RedisModuleCtx* ctx, size_t numThreads, char *password, bool topologyEvents);
+
+/* Initialize mr library without topology events.
+ * Kept at the pre-topology-events signature so consumers that predate them (RedisTimeSeries 8.8
+ * and older) build against this library unchanged; equivalent to
+ * MR_InitWithTopologyEvents(..., false). */
+LIBMR_API int MR_Init(struct RedisModuleCtx* ctx, size_t numThreads, char *password);
 
 /* Resize the execution thread pool with a new size if worker threads were never started.
  * Requires MR_Init() to have created the pool. Returns REDISMODULE_ERR if the pool does not


### PR DESCRIPTION
## Competing with #120 — pick one, not both

Two ways to get the MOD-16600 fix (#116) onto the RTS 8.8 line:

- **#120** — maintenance branch `8.8` in this repo + a cherry-pick per backport.
- **this PR** — make master build against the older consumers, so RTS 8.8 just bumps `deps/LibMR` to master and every future fix comes for free.

I opened #120 first; Tom pushed back on adding a release branch, and he's right that this is the better shape if it holds. It does.

## The compatibility surface is exactly one function

RTS 8.8 references **39** `MR_*` symbols; **32** are declared in our headers. Diffing every one of those declarations between `a37b672` (what RTS 8.8/8.6/8.4 pin) and `c6a5ed62` (master):

```
CHANGED MR_Init
   old: LIBMR_API int MR_Init(RedisModuleCtx*, size_t numThreads, char *password);
   new: LIBMR_API int MR_Init(RedisModuleCtx*, size_t numThreads, char *password, bool topologyEvents);

changed: 1   removed: 0
```

That is the whole break. `MR_ClusterInit` also gained the flag but is not `LIBMR_API` and no consumer calls it. `MR_BuildCluster`, `MR_UpdateClusterTopologyIfNeeded*`, `MR_ClusterGetPassword` and `MR_UpdateClusterTopology` were *added*, and additions don't break anyone.

## The change

`MR_Init` goes back to three arguments; the new capability becomes `MR_InitWithTopologyEvents`. Old consumers build unchanged, new ones opt in by name. `rust_api`'s `mr_init` keeps its signature and binds the new symbol, so the bindgen-generated bindings and `tests/mr_test_module` are untouched.

## Why the topology-event code is safe to ship to 8.8

Not just "disabled" — **unreachable**. Redis on that line does not emit the notification at all; the Enterprise cluster plugin says so on startup:

```
ClusterPlugin: Failed to load symbol: "clusterNotifyTopologyChanged",
               assuming this an old redis version w/out ASM
```

(from the RE 8.8 shard log in RED-211253). With no event: `MR_TopologyEventSeen` stays false, the `RedisModule_Assert(!MR_TopologyEventSeen)` in both CLUSTERSET paths holds, and `MR_UpdateClusterTopology()` is only ever called by a consumer that registered a handler. The three-argument `MR_Init` makes that explicit by never setting the flag.

## Verification

- `make libmr` builds; `nm` shows both `MR_Init` and `MR_InitWithTopologyEvents` exported from `src/libmr.a`.
- A translation unit calling the three-argument `MR_Init` **exactly as RTS 8.8 does** (`src/libmr_integration.c:1025`) compiles with 0 errors — RTS 8.8 needs no source change.
- A translation unit calling `MR_InitWithTopologyEvents` compiles with 0 errors.

## What I have not verified, and would want to before 8.8 actually adopts master

- A full RTS 8.8 build and flow run against master (my Docker host went down mid-check; the C-level checks above are native).
- That the **other** commits master carries since `a37b672` are all acceptable on a release line. #104 (skip unchanged CLUSTERSET) and #108 (execution leak) look wanted; #117/#119 are topology-event adjustments and therefore inert per the above; but **#111/#115 change the inter-shard TLS gate** (`tls-cluster`) and that is a genuine behaviour change on 8.8 — worth a deliberate look rather than inheriting it silently.

If the TLS change is unacceptable for 8.8, #120 is still the safer route and this PR should be closed. If it's fine, merge this, close #120, and delete the `8.8` branch I created there.

## RTS side

RTS master's call site moves to `MR_InitWithTopologyEvents` (one line). RTS 8.8/8.6/8.4 change nothing but the submodule pin. I'll open those once we've picked a direction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized API split with backward-compatible `MR_Init`; default remains no topology events, matching pre-change behavior for existing consumers.
> 
> **Overview**
> **Restores ABI compatibility** for consumers (e.g. RedisTimeSeries 8.8) that still call the original three-argument `MR_Init(ctx, numThreads, password)` after master had added a fourth `topologyEvents` parameter.
> 
> The four-argument behavior moves to **`MR_InitWithTopologyEvents`**, which performs the real initialization (including `MR_ClusterInit(..., topologyEvents)`). **`MR_Init`** is a thin wrapper that calls it with `topologyEvents=false`, so legacy binaries keep working without recompiling and topology-event paths stay off unless a consumer explicitly opts in and drives `MR_UpdateClusterTopology()`.
> 
> **`mr.h`** documents both entry points. **`rust_api`**’s `mr_init` now binds **`MR_InitWithTopologyEvents`** instead of **`MR_Init`**, preserving the Rust API’s `topology_events` flag without changing bindgen call sites beyond the symbol name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39ed17d244c4264be0dd5a32f0623b1e7b260a24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->