### PR TITLE
MOD-17518 Don't register internal commands as `internal` on enterprise

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -163,11 +163,8 @@ struct ClusterCtx {
     size_t clusterSize;
     char myId[REDISMODULE_NODE_ID_LEN + 1];
     int isOss;
-    /* Whether our commands were registered with the `internal` flag, i.e. are
-     * only visible on an internal connection. This is a separate decision from
-     * `isOss`: `isOss` says where the topology comes from, while this says which
-     * commands are visible to us and therefore how we must authenticate - see
-     * the comment in MR_ClusterInit(). */
+    /* Our commands were registered `internal`, so only an internal connection
+     * sees them. Not the same question as `isOss` - see MR_ClusterInit(). */
     bool commandsAreInternal;
     functionId networkTestMsgReceiver;
     char *password;
@@ -426,13 +423,11 @@ static void MR_AuthResponseArrived(struct redisAsyncContext* c, void* a, void* b
     }
     Node* n = (Node*)b;
     if (!c->data) {
-        // the node is gone, same guard as MR_HelloResponseArrived
+        // the node is gone
         return;
     }
-    /* A failed AUTH leaves us on a connection with fewer privileges than we
-     * expect, on which the commands we registered may not even be visible. It is
-     * not recoverable from here, but it must not be silent - it is the difference
-     * between diagnosing this and staring at `unknown command` retries. */
+    /* Not recoverable from here, but a silent AUTH failure only resurfaces later
+     * as `unknown command` on the hello. */
     RedisModule_Log(mr_staticCtx, "warning",
         "AUTH to %s (%s:%d) failed: %s. The connection will not have the expected "
         "privileges and the hello handshake is likely to fail.",
@@ -451,8 +446,7 @@ static void SendInternalSecretAuth(const struct redisAsyncContext* c, const Node
 
 static void SendAuthCommandIfNeeded(const struct redisAsyncContext* c, const Node *n) {
     if (clusterCtx.commandsAreInternal) {
-        /* Only an internal connection can see the commands we registered, so a
-         * password is of no use here even if a CLUSTERSET handed us one. */
+        /* A password cannot make the connection internal. */
         SendInternalSecretAuth(c, n);
         return;
     }
@@ -462,10 +456,7 @@ static void SendAuthCommandIfNeeded(const struct redisAsyncContext* c, const Nod
         return;
     }
     if (RedisModule_GetInternalSecret && clusterCtx.isOss) {
-        /* No password to use, but the server may still require us to
-         * authenticate (e.g. requirepass), and the internal secret is the one
-         * credential we always have. Our commands are visible on a regular
-         * connection here, so this is only about being authenticated at all. */
+        /* No password, but the server may still require us to authenticate. */
         SendInternalSecretAuth(c, n);
     }
 }
@@ -1951,12 +1942,8 @@ int MR_ClusterInit(RedisModuleCtx* rctx, char *password, bool topologyEvents) {
      * Treat the shard as enterprise only when rlec_version is present AND we
      * are not in OSS cluster mode: it unblocks an enterprise binary running as
      * an OSS cluster (e.g. the env0 testing setup), which must read its topology
-     * from the native cluster view rather than wait for a DMC CLUSTERSET.
-     *
-     * Note that this decides the *topology source* only. How we authenticate,
-     * and therefore which commands are visible on our inter-shard connections,
-     * is decided separately below - the two are not the same question, and an
-     * enterprise binary in OSS cluster mode answers them differently. */
+     * from the native cluster view rather than wait for a DMC CLUSTERSET. This
+     * decides the topology source only; the command flags are decided below. */
     if (MR_RlecVersionPresent && !ossClusterRuntime) {
         clusterCtx.isOss = false;
     }
@@ -1965,25 +1952,16 @@ int MR_ClusterInit(RedisModuleCtx* rctx, char *password, bool topologyEvents) {
                     clusterCtx.isOss ? "oss" : "enterprise",
                     ossClusterRuntime ? "yes" : "no");
 
-    /* Whether we can authenticate our inter-shard connections as internal ones.
-     * This is deliberately *not* keyed off `clusterCtx.isOss`: an enterprise
-     * shard gets its topology (and its credentials) from DMC through CLUSTERSET,
-     * and authenticates with the password carried in the `ADDR <pwd>@<ip>:<port>`
-     * entry - see SendAuthCommandIfNeeded(). That yields a regular, non-internal
-     * connection, on which commands registered with the `internal` flag are
-     * hidden from us; the HELLO handshake then fails with `unknown command` and
-     * never recovers. So an enterprise binary must never register them as
-     * `internal`, not even when it runs with cluster-enabled=yes - which is a
-     * per-database property there (enabled for the OSS cluster API and/or ASM),
-     * not a property of the deployment. */
+    /* Not keyed off `isOss`: an enterprise shard authenticates with the password
+     * from CLUSTERSET, which gives a regular connection that cannot see
+     * `internal` commands, so the hello fails `unknown command` forever. Note
+     * that cluster-enabled is per-database there, so isOss may well be true. */
     clusterCtx.commandsAreInternal = clusterCtx.isOss && !MR_RlecVersionPresent &&
                                      RedisModule_GetInternalSecret != NULL;
 
     const char *command_flags = "readonly deny-script";
     if (MR_RlecVersionPresent) {
-        /* An enterprise binary understands `_proxy-filtered` regardless of the
-         * cluster mode it runs in, and needs it so the proxy hides these
-         * commands from clients. */
+        /* Understood, and needed, regardless of the cluster mode we run in. */
         command_flags = "readonly deny-script _proxy-filtered";
     } else if (clusterCtx.commandsAreInternal) {
         /* We run at a version that supports internal commands, let use it. */
@@ -2066,8 +2044,6 @@ const char* MR_ClusterGetMyId(){
 }
 
 const char *MR_ClusterGetPassword(){
-    /* Only drop the password when our commands are internal, since then only an
-     * internal connection is of any use to us; otherwise the password may be the
-     * only credential we have. */
+    /* Only drop it when nothing but an internal connection is of use to us. */
     return clusterCtx.commandsAreInternal ? NULL : clusterCtx.password;
 }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -434,20 +434,28 @@ static void MR_AuthResponseArrived(struct redisAsyncContext* c, void* a, void* b
         n->id, n->ip, n->port, reply->str);
 }
 
-static void SendInternalSecretAuth(const struct redisAsyncContext* c, const Node *n) {
+/* The secret is only set where the server actually has one to share, so it can
+ * be NULL even when the API is available - a cluster wired up by CLUSTERSET
+ * alone never gets one. Returns false when there is nothing to send. */
+static bool TrySendInternalSecretAuth(const struct redisAsyncContext* c, const Node *n) {
+    if (!RedisModule_GetInternalSecret) {
+        return false;
+    }
     RedisModule_ThreadSafeContextLock(mr_staticCtx);
     size_t len;
     const char *secret = RedisModule_GetInternalSecret(mr_staticCtx, &len);
-    RedisModule_Assert(secret);
-    redisAsyncCommand((redisAsyncContext*)c, MR_AuthResponseArrived, (void*)n,
-                      "AUTH %s %b", "internal connection", secret, len);
+    if (secret) {
+        redisAsyncCommand((redisAsyncContext*)c, MR_AuthResponseArrived, (void*)n,
+                          "AUTH %s %b", "internal connection", secret, len);
+    }
     RedisModule_ThreadSafeContextUnlock(mr_staticCtx);
+    return secret != NULL;
 }
 
 static void SendAuthCommandIfNeeded(const struct redisAsyncContext* c, const Node *n) {
-    if (clusterCtx.commandsAreInternal) {
-        /* A password cannot make the connection internal. */
-        SendInternalSecretAuth(c, n);
+    /* Prefer the internal secret when our commands are internal, since only an
+     * internal connection can see them and a password cannot make one. */
+    if (clusterCtx.commandsAreInternal && TrySendInternalSecretAuth(c, n)) {
         return;
     }
     if (n->password){
@@ -455,9 +463,9 @@ static void SendAuthCommandIfNeeded(const struct redisAsyncContext* c, const Nod
         redisAsyncCommand((redisAsyncContext*)c, MR_AuthResponseArrived, (void*)n, "AUTH %s", n->password);
         return;
     }
-    if (RedisModule_GetInternalSecret && clusterCtx.isOss) {
+    if (clusterCtx.isOss) {
         /* No password, but the server may still require us to authenticate. */
-        SendInternalSecretAuth(c, n);
+        TrySendInternalSecretAuth(c, n);
     }
 }
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -163,12 +163,12 @@ struct ClusterCtx {
     size_t clusterSize;
     char myId[REDISMODULE_NODE_ID_LEN + 1];
     int isOss;
-    /* Whether the inter-shard connections are authenticated as *internal*
-     * connections (`AUTH "internal connection" <secret>`). This is a separate
-     * decision from `isOss`: `isOss` says where the topology comes from, while
-     * this says how we authenticate and therefore which commands are visible to
-     * us. They must agree - see the comment in MR_ClusterInit(). */
-    bool useInternalConn;
+    /* Whether our commands were registered with the `internal` flag, i.e. are
+     * only visible on an internal connection. This is a separate decision from
+     * `isOss`: `isOss` says where the topology comes from, while this says which
+     * commands are visible to us and therefore how we must authenticate - see
+     * the comment in MR_ClusterInit(). */
+    bool commandsAreInternal;
     functionId networkTestMsgReceiver;
     char *password;
     bool topologyEvents;
@@ -434,30 +434,39 @@ static void MR_AuthResponseArrived(struct redisAsyncContext* c, void* a, void* b
      * not recoverable from here, but it must not be silent - it is the difference
      * between diagnosing this and staring at `unknown command` retries. */
     RedisModule_Log(mr_staticCtx, "warning",
-        "AUTH to %s (%s:%d) failed (%s auth): %s. The connection will not have the "
-        "expected privileges and the hello handshake is likely to fail.",
-        n->id, n->ip, n->port,
-        clusterCtx.useInternalConn ? "internal-secret" : "password", reply->str);
+        "AUTH to %s (%s:%d) failed: %s. The connection will not have the expected "
+        "privileges and the hello handshake is likely to fail.",
+        n->id, n->ip, n->port, reply->str);
+}
+
+static void SendInternalSecretAuth(const struct redisAsyncContext* c, const Node *n) {
+    RedisModule_ThreadSafeContextLock(mr_staticCtx);
+    size_t len;
+    const char *secret = RedisModule_GetInternalSecret(mr_staticCtx, &len);
+    RedisModule_Assert(secret);
+    redisAsyncCommand((redisAsyncContext*)c, MR_AuthResponseArrived, (void*)n,
+                      "AUTH %s %b", "internal connection", secret, len);
+    RedisModule_ThreadSafeContextUnlock(mr_staticCtx);
 }
 
 static void SendAuthCommandIfNeeded(const struct redisAsyncContext* c, const Node *n) {
-    if (clusterCtx.useInternalConn) {
-        /* Our commands are registered as internal, so the connection has to be an
-         * internal one - a password would give us a regular connection on which
-         * they are hidden. Authenticate with the internal secret even if a
-         * CLUSTERSET handed us a password. */
-        RedisModule_ThreadSafeContextLock(mr_staticCtx);
-        size_t len;
-        const char *secret = RedisModule_GetInternalSecret(mr_staticCtx, &len);
-        RedisModule_Assert(secret);
-        redisAsyncCommand((redisAsyncContext*)c, MR_AuthResponseArrived, (void*)n,
-                          "AUTH %s %b", "internal connection", secret, len);
-        RedisModule_ThreadSafeContextUnlock(mr_staticCtx);
+    if (clusterCtx.commandsAreInternal) {
+        /* Only an internal connection can see the commands we registered, so a
+         * password is of no use here even if a CLUSTERSET handed us one. */
+        SendInternalSecretAuth(c, n);
         return;
     }
     if (n->password){
         /* If password is provided to us we will use it (it means it was given to us with clusterset) */
         redisAsyncCommand((redisAsyncContext*)c, MR_AuthResponseArrived, (void*)n, "AUTH %s", n->password);
+        return;
+    }
+    if (RedisModule_GetInternalSecret && clusterCtx.isOss) {
+        /* No password to use, but the server may still require us to
+         * authenticate (e.g. requirepass), and the internal secret is the one
+         * credential we always have. Our commands are visible on a regular
+         * connection here, so this is only about being authenticated at all. */
+        SendInternalSecretAuth(c, n);
     }
 }
 
@@ -484,7 +493,7 @@ static void MR_HelloResponseArrived(struct redisAsyncContext* c, void* a, void* 
             // accepted connections but did not set its internal secret to the cluster's yet.
             // In such cases we will have a regular (i.e., non-internal) connection and the
             // hidden commands (including `<module>.HELLO`) will not be visible to us.
-            if (clusterCtx.useInternalConn && strstr(reply->str, "unknown command") != NULL)
+            if (clusterCtx.commandsAreInternal && strstr(reply->str, "unknown command") != NULL)
                 SendAuthCommandIfNeeded(c, n);
         }
         n->resendHelloEvent = MR_EventLoopAddTaskWithDelay(MR_ClusterResendHelloMessage, n, RETRY_INTERVAL);
@@ -1967,8 +1976,8 @@ int MR_ClusterInit(RedisModuleCtx* rctx, char *password, bool topologyEvents) {
      * `internal`, not even when it runs with cluster-enabled=yes - which is a
      * per-database property there (enabled for the OSS cluster API and/or ASM),
      * not a property of the deployment. */
-    clusterCtx.useInternalConn = clusterCtx.isOss && !MR_RlecVersionPresent &&
-                                 RedisModule_GetInternalSecret != NULL;
+    clusterCtx.commandsAreInternal = clusterCtx.isOss && !MR_RlecVersionPresent &&
+                                     RedisModule_GetInternalSecret != NULL;
 
     const char *command_flags = "readonly deny-script";
     if (MR_RlecVersionPresent) {
@@ -1976,7 +1985,7 @@ int MR_ClusterInit(RedisModuleCtx* rctx, char *password, bool topologyEvents) {
          * cluster mode it runs in, and needs it so the proxy hides these
          * commands from clients. */
         command_flags = "readonly deny-script _proxy-filtered";
-    } else if (clusterCtx.useInternalConn) {
+    } else if (clusterCtx.commandsAreInternal) {
         /* We run at a version that supports internal commands, let use it. */
         command_flags = "readonly deny-script internal";
     }
@@ -2057,7 +2066,8 @@ const char* MR_ClusterGetMyId(){
 }
 
 const char *MR_ClusterGetPassword(){
-    /* Only drop the password when we are actually going to authenticate as an
-     * internal connection; otherwise it is the only credential we have. */
-    return clusterCtx.useInternalConn ? NULL : clusterCtx.password;
+    /* Only drop the password when our commands are internal, since then only an
+     * internal connection is of any use to us; otherwise the password may be the
+     * only credential we have. */
+    return clusterCtx.commandsAreInternal ? NULL : clusterCtx.password;
 }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -163,6 +163,12 @@ struct ClusterCtx {
     size_t clusterSize;
     char myId[REDISMODULE_NODE_ID_LEN + 1];
     int isOss;
+    /* Whether the inter-shard connections are authenticated as *internal*
+     * connections (`AUTH "internal connection" <secret>`). This is a separate
+     * decision from `isOss`: `isOss` says where the topology comes from, while
+     * this says how we authenticate and therefore which commands are visible to
+     * us. They must agree - see the comment in MR_ClusterInit(). */
+    bool useInternalConn;
     functionId networkTestMsgReceiver;
     char *password;
     bool topologyEvents;
@@ -413,20 +419,45 @@ static void MR_ClusterResendHelloMessage(void* ctx){
     redisAsyncCommand((redisAsyncContext*)n->c, MR_HelloResponseArrived, n, CLUSTER_HELLO_COMMAND);
 }
 
-static void SendAuthCommandIfNeeded(const struct redisAsyncContext* c, const Node *n) {
-    if (n->password){
-        /* If password is provided to us we will use it (it means it was given to us with clusterset) */
-        redisAsyncCommand((redisAsyncContext*)c, NULL, NULL, "AUTH %s", n->password);
+static void MR_AuthResponseArrived(struct redisAsyncContext* c, void* a, void* b){
+    redisReply* reply = (redisReply*)a;
+    if (!reply || reply->type != REDIS_REPLY_ERROR) {
         return;
     }
-    if (RedisModule_GetInternalSecret && clusterCtx.isOss) {
-        /* OSS deployment that support internal secret, lets use it. */
+    Node* n = (Node*)b;
+    if (!c->data) {
+        // the node is gone, same guard as MR_HelloResponseArrived
+        return;
+    }
+    /* A failed AUTH leaves us on a connection with fewer privileges than we
+     * expect, on which the commands we registered may not even be visible. It is
+     * not recoverable from here, but it must not be silent - it is the difference
+     * between diagnosing this and staring at `unknown command` retries. */
+    RedisModule_Log(mr_staticCtx, "warning",
+        "AUTH to %s (%s:%d) failed (%s auth): %s. The connection will not have the "
+        "expected privileges and the hello handshake is likely to fail.",
+        n->id, n->ip, n->port,
+        clusterCtx.useInternalConn ? "internal-secret" : "password", reply->str);
+}
+
+static void SendAuthCommandIfNeeded(const struct redisAsyncContext* c, const Node *n) {
+    if (clusterCtx.useInternalConn) {
+        /* Our commands are registered as internal, so the connection has to be an
+         * internal one - a password would give us a regular connection on which
+         * they are hidden. Authenticate with the internal secret even if a
+         * CLUSTERSET handed us a password. */
         RedisModule_ThreadSafeContextLock(mr_staticCtx);
         size_t len;
         const char *secret = RedisModule_GetInternalSecret(mr_staticCtx, &len);
         RedisModule_Assert(secret);
-        redisAsyncCommand((redisAsyncContext*)c, NULL, NULL, "AUTH %s %b", "internal connection", secret, len);
+        redisAsyncCommand((redisAsyncContext*)c, MR_AuthResponseArrived, (void*)n,
+                          "AUTH %s %b", "internal connection", secret, len);
         RedisModule_ThreadSafeContextUnlock(mr_staticCtx);
+        return;
+    }
+    if (n->password){
+        /* If password is provided to us we will use it (it means it was given to us with clusterset) */
+        redisAsyncCommand((redisAsyncContext*)c, MR_AuthResponseArrived, (void*)n, "AUTH %s", n->password);
     }
 }
 
@@ -453,7 +484,7 @@ static void MR_HelloResponseArrived(struct redisAsyncContext* c, void* a, void* 
             // accepted connections but did not set its internal secret to the cluster's yet.
             // In such cases we will have a regular (i.e., non-internal) connection and the
             // hidden commands (including `<module>.HELLO`) will not be visible to us.
-            if (clusterCtx.isOss && strstr(reply->str, "unknown command") != NULL)
+            if (clusterCtx.useInternalConn && strstr(reply->str, "unknown command") != NULL)
                 SendAuthCommandIfNeeded(c, n);
         }
         n->resendHelloEvent = MR_EventLoopAddTaskWithDelay(MR_ClusterResendHelloMessage, n, RETRY_INTERVAL);
@@ -1909,10 +1940,14 @@ int MR_ClusterInit(RedisModuleCtx* rctx, char *password, bool topologyEvents) {
      * present-but-unparseable rlec_version would otherwise read as OSS.
      *
      * Treat the shard as enterprise only when rlec_version is present AND we
-     * are not in OSS cluster mode. This is the load-bearing decision of the
-     * PR: it unblocks an enterprise binary running as an OSS cluster (e.g. the
-     * env0 testing setup), which must take the OSS path (internal-secret AUTH,
-     * no _proxy-filtered command flags) rather than the enterprise path. */
+     * are not in OSS cluster mode: it unblocks an enterprise binary running as
+     * an OSS cluster (e.g. the env0 testing setup), which must read its topology
+     * from the native cluster view rather than wait for a DMC CLUSTERSET.
+     *
+     * Note that this decides the *topology source* only. How we authenticate,
+     * and therefore which commands are visible on our inter-shard connections,
+     * is decided separately below - the two are not the same question, and an
+     * enterprise binary in OSS cluster mode answers them differently. */
     if (MR_RlecVersionPresent && !ossClusterRuntime) {
         clusterCtx.isOss = false;
     }
@@ -1921,14 +1956,28 @@ int MR_ClusterInit(RedisModuleCtx* rctx, char *password, bool topologyEvents) {
                     clusterCtx.isOss ? "oss" : "enterprise",
                     ossClusterRuntime ? "yes" : "no");
 
+    /* Whether we can authenticate our inter-shard connections as internal ones.
+     * This is deliberately *not* keyed off `clusterCtx.isOss`: an enterprise
+     * shard gets its topology (and its credentials) from DMC through CLUSTERSET,
+     * and authenticates with the password carried in the `ADDR <pwd>@<ip>:<port>`
+     * entry - see SendAuthCommandIfNeeded(). That yields a regular, non-internal
+     * connection, on which commands registered with the `internal` flag are
+     * hidden from us; the HELLO handshake then fails with `unknown command` and
+     * never recovers. So an enterprise binary must never register them as
+     * `internal`, even when it runs with cluster-enabled=yes (which is the case
+     * for every ASM-enabled database). */
+    clusterCtx.useInternalConn = clusterCtx.isOss && !MR_RlecVersionPresent &&
+                                 RedisModule_GetInternalSecret != NULL;
+
     const char *command_flags = "readonly deny-script";
-    if (!clusterCtx.isOss) {
+    if (MR_RlecVersionPresent) {
+        /* An enterprise binary understands `_proxy-filtered` regardless of the
+         * cluster mode it runs in, and needs it so the proxy hides these
+         * commands from clients. */
         command_flags = "readonly deny-script _proxy-filtered";
-    } else {
-        if (RedisModule_GetInternalSecret) {
-            /* We run at a version that supports internal commands, let use it. */
-            command_flags = "readonly deny-script internal";
-        }
+    } else if (clusterCtx.useInternalConn) {
+        /* We run at a version that supports internal commands, let use it. */
+        command_flags = "readonly deny-script internal";
     }
 
     if (clusterCtx.isOss) {
@@ -1943,7 +1992,7 @@ int MR_ClusterInit(RedisModuleCtx* rctx, char *password, bool topologyEvents) {
     /* The CLUSTERSET should be visible in COMMAND LIST, otherwise the RAMP packer
      * will miss it and a module will not be notified in an enterprise cluster */
     if (!RegisterRedisCommand(rctx, CLUSTER_SET_COMMAND, MR_ClusterSet,
-                            !clusterCtx.isOss ? "readonly deny-script _proxy-filtered" : "readonly deny-script",
+                            MR_RlecVersionPresent ? "readonly deny-script _proxy-filtered" : "readonly deny-script",
                             0, 0, -1)) {
         return REDISMODULE_ERR;
     }
@@ -2007,5 +2056,7 @@ const char* MR_ClusterGetMyId(){
 }
 
 const char *MR_ClusterGetPassword(){
-    return RedisModule_GetInternalSecret ? NULL : clusterCtx.password;
+    /* Only drop the password when we are actually going to authenticate as an
+     * internal connection; otherwise it is the only credential we have. */
+    return clusterCtx.useInternalConn ? NULL : clusterCtx.password;
 }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1964,8 +1964,9 @@ int MR_ClusterInit(RedisModuleCtx* rctx, char *password, bool topologyEvents) {
      * connection, on which commands registered with the `internal` flag are
      * hidden from us; the HELLO handshake then fails with `unknown command` and
      * never recovers. So an enterprise binary must never register them as
-     * `internal`, even when it runs with cluster-enabled=yes (which is the case
-     * for every ASM-enabled database). */
+     * `internal`, not even when it runs with cluster-enabled=yes - which is a
+     * per-database property there (enabled for the OSS cluster API and/or ASM),
+     * not a property of the deployment. */
     clusterCtx.useInternalConn = clusterCtx.isOss && !MR_RlecVersionPresent &&
                                  RedisModule_GetInternalSecret != NULL;
 


### PR DESCRIPTION
## Problem

On an Enterprise database whose shards run in cluster mode, the libmr cluster never forms. Both masters sit in this loop at 1 Hz for as long as the database lives:

```
# <timeseries> Got bad hello response from 0000...000197 (10.0.101.246:25128), will try again in 1 second, ERR unknown command 'timeseries.HELLO'.
```

Every coordinated command then dies on the max-idle timeout, which is what fails `test_asm_scale_in_out_with_workload` (see MOD-17016).

The command is **hidden, not missing**. In the support packages the initiator gets `unknown command` **from its own ip:port** — LibMR deliberately connects to its own node for internal-function fan-out (`cluster.c:281` + the lazy connect at `cluster.c:252`), so the process replying "unknown command" is the process that registered the command.

## Cause

`isOss` is answering two unrelated questions at once — *where does the topology come from* and *how do we authenticate / which commands are visible to us*.

Since #98, an Enterprise binary running with `cluster-enabled=yes` is classified as OSS. That is correct for the topology source (it must read the native cluster view), but it also selected the `internal` command flag at `cluster.c:1902`. Meanwhile an Enterprise shard authenticates with the password DMC puts in the long-form CLUSTERSET (`ADDR <pwd>@<ip>:<port>`), and `SendAuthCommandIfNeeded()` returns as soon as it has used it — so the connection is a regular one, and `internal`-flagged commands are invisible on it. The retry path re-sends the same password, so it never recovers. LibMR's own comment at `cluster.c:458-461` already describes this outcome.

### Which databases are affected

`cluster-enabled` is **per database** on Enterprise, not a property of the deployment: RE sets it for the OSS cluster API and/or for ASM. So the trigger is "this database's shards run in cluster mode", and ASM is one route to it, not the only one — a database with the OSS cluster API enabled reaches the same broken combination with no ASM involved.

The support packages I have only contain the ASM route (`oss_cluster=disabled`, `redis_cluster_enabled=enabled`), so that is the only one directly observed; the OSS-cluster-API route follows from the same code path and is worth an explicit test.

The correlation in one package is exact: 4 of 344 shard processes log `Running mode=cluster` → exactly the ASM database's shards → exactly the only ones logging `Detected redis oss (cluster-enabled=yes)` → exactly the only ones with the HELLO storm. The other 340 log `Detected redis enterprise (cluster-enabled=no)` and are healthy.

Affected pins: `v8.8.2` (`a37b672`) and `master` (`c6a5ed6`) include #98; `v8.8.1` (`44d5025`) does not and is clean.

## Change

Keep `isOss` for the topology source, and decide the connection/visibility model from whether this is an Enterprise binary:

- `_proxy-filtered` whenever `rlec_version` is present, regardless of cluster mode; `internal` only when we will actually authenticate as an internal connection.
- New `clusterCtx.useInternalConn`, used for the auth mode in `SendAuthCommandIfNeeded()` and for whether `MR_ClusterGetPassword()` may drop the password — so the flags and the auth can no longer disagree.
- Prefer the internal secret over a CLUSTERSET password when the commands are internal, since a password cannot make a connection internal.
- Log a failed AUTH. It was fire-and-forget with a `NULL` callback, which is why half an hour of broken handshake produced no diagnostic beyond `unknown command`.

`CLUSTERSET` itself also moves to `_proxy-filtered` on any Enterprise binary; previously a cluster-mode database exposed it to clients through the proxy.

Because the decision is keyed off the binary rather than the cluster mode, it covers both routes into cluster mode identically.

## Effect

On the failing run this is sufficient: the long-form CLUSTERSET already supplies the password, the flags become `_proxy-filtered` (visible on a password-authenticated connection), HELLO succeeds, the fan-out forms.

Cost: #98's target scenario (an Enterprise binary running a plain OSS cluster in env0) loses the `internal` hiding — it gets `_proxy-filtered` and keeps internal-secret AUTH via the `n->password == NULL` path. Functionally unchanged, slightly less hardened.

## Verification

`cluster.c` compiles clean. The behaviour needs a live cluster-mode Enterprise database to verify: a master shard log should show `Detected redis oss (cluster-enabled=yes)` **and zero** `Got bad hello response`. Today those two are mutually exclusive.

Two things I could not verify locally and would like a second opinion on:

1. That an Enterprise binary accepts `_proxy-filtered` while running with `cluster-enabled=yes`. If it does not, that branch should fall back to plain `"readonly deny-script"`.
2. Whether Enterprise ever propagates a *shared* internal secret to a database's shards. The evidence says no — one package took the short-form path, so `MR_ClusterGetPassword()` returned `NULL`, the internal-secret AUTH *was* sent, and it still failed. If RE can share it, the opposite fix becomes viable (always prefer internal-secret AUTH and keep `internal` everywhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster handshake, command ACL flags, and AUTH selection across OSS vs Enterprise and cluster-enabled combinations; wrong classification could still break HELLO or expose commands differently on proxy paths.
> 
> **Overview**
> Fixes LibMR cluster formation on **Enterprise shards with `cluster-enabled=yes`**, where inter-shard `HELLO` failed with `unknown command` because commands were registered as `internal` while shard links authenticated with the CLUSTERSET password (a regular, non-internal connection).
> 
> **`isOss`** still only picks the topology source (native cluster vs DMC CLUSTERSET). A new **`commandsAreInternal`** flag decides whether module commands are registered `internal` and whether password-based auth is appropriate—true only for plain OSS binaries with internal-secret support, not when `rlec_version` is present.
> 
> On Enterprise binaries, cluster commands (including **`CLUSTERSET`**) now use **`_proxy-filtered`** instead of `internal`, so they remain visible on password-authenticated shard connections. **`SendAuthCommandIfNeeded`** prefers internal-secret AUTH when commands are internal; internal secret is optional (no assert). Failed **AUTH** responses are logged via **`MR_AuthResponseArrived`**. **`MR_ClusterGetPassword`** omits the stored password only when internal connections are required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7ff12c831ad41888f4bac80fe947fa52fd3144c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->